### PR TITLE
fix(sdk): fix crash when detaching script components within OnTick()

### DIFF
--- a/src/BmSDK/Classes/Engine/Actor.cs
+++ b/src/BmSDK/Classes/Engine/Actor.cs
@@ -9,7 +9,7 @@ public partial class Actor
     /// <summary>
     /// Collection of all ScriptComponent instances attached to every actor.
     /// </summary>
-    public static IReadOnlyList<IScriptComponent> AllScriptComponents => s_scriptComponents;
+    public static IReadOnlyCollection<IScriptComponent> AllScriptComponents => s_scriptComponents;
 
     static readonly List<IScriptComponent> s_scriptComponents = [];
 

--- a/src/BmSDK/Loader.cs
+++ b/src/BmSDK/Loader.cs
@@ -127,13 +127,14 @@ static class Loader
                 ScriptManager.Scripts.ForEach(script => Debug.RunWithSender(script.Name, script.OnTick));
 
                 // Call OnTick() for script components
-                var scriptComponents = Actor.AllScriptComponents;
-                for (var i = scriptComponents.Count - 1; i >= 0; i--)
+                if (Actor.AllScriptComponents.Count > 0)
                 {
-                    Debug.RunWithSender(
-                        scriptComponents[i].GetType().Name,
-                        scriptComponents[i].OnTick
-                    );
+                    foreach (var scriptComponent in Actor.AllScriptComponents.ToArray())
+                    {
+                        Debug.RunWithSender(
+                            scriptComponent.GetType().Name,
+                            scriptComponent.OnTick);
+                    }
                 }
             }
 


### PR DESCRIPTION
Originally fixed by #10, reintroduced by #30 presumably as an optimization