### PR TITLE
fix: print FName suffixes

### DIFF
--- a/src/BmSDK/Classes/Core/FName.cs
+++ b/src/BmSDK/Classes/Core/FName.cs
@@ -12,7 +12,7 @@ public struct FName
     /// <summary>
     /// Creates a new FName with the given index.
     /// </summary>
-    public unsafe FName(int index)
+    public FName(int index)
     {
         Index = index;
         Number = 0;
@@ -49,10 +49,12 @@ public struct FName
         var GNamesData = *GNames;
 
 #if BATMAN2
-        return Guard.NotNull(Marshal.PtrToStringUni((IntPtr)GNamesData[Index]->UniName));
+        var str = Guard.NotNull(Marshal.PtrToStringUni((IntPtr)GNamesData[Index]->UniName));
 #elif BATMAN3
-        return Guard.NotNull(Marshal.PtrToStringAnsi((IntPtr)GNamesData[Index]->UniName));
+        var str = Guard.NotNull(Marshal.PtrToStringAnsi((IntPtr)GNamesData[Index]->UniName));
 #endif
+        return Number == 0 ? str : $"{str}_{Number}";
+
     }
 
 #pragma warning disable CS0649

--- a/src/BmSDK/Classes/Core/FName.cs
+++ b/src/BmSDK/Classes/Core/FName.cs
@@ -53,7 +53,7 @@ public struct FName
 #elif BATMAN3
         var str = Guard.NotNull(Marshal.PtrToStringAnsi((IntPtr)GNamesData[Index]->UniName));
 #endif
-        return Number == 0 ? str : $"{str}_{Number}";
+        return Number == 0 ? str : $"{str}_{Number - 1}";
 
     }
 


### PR DESCRIPTION
When multiple `FName`s with the same text are created, UE3 reuses the same `FNameEntry` but increments `Number`. UE3's `GetName()` normally prints these as `{Name}` if Number is still 0 (the first-ever use of that name), but it instead prints `{Name}_{Number-1}` if there are multiple.

In this patch, we do the same in BmSDK. Right now this introduces a handful of runtime warnings that I still need to investigate, mainly around `RLadder`.