### PR TITLE
feat: support object preloading for mods

### DIFF
--- a/src/BmSDK/FrameworkInternal/GameFunctions.cs
+++ b/src/BmSDK/FrameworkInternal/GameFunctions.cs
@@ -28,6 +28,13 @@ internal static class GameFunctions
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate IntPtr LoadPackageDelegate(IntPtr InOuter, IntPtr Filename, int LoadFlags);
 
+    // UObject::CollectGarbage()
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void CollectGarbageDelegate(
+        GameObject.EObjectFlags KeepFlags,
+        int bPerformFullPurge
+    );
+
     // UObject::ProcessEvent()
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
     public delegate void ProcessEventDelegate(
@@ -115,6 +122,7 @@ internal static class GameFunctions
     private static StaticConstructObjectDelegate? _StaticConstructObject = null;
     private static StaticFindObjectDelegate? _StaticFindObject = null;
     private static LoadPackageDelegate? _LoadPackage = null;
+    private static CollectGarbageDelegate? _CollectGarbage = null;
     private static ProcessEventDelegate? _ProcessEvent = null;
     private static ProcessInternalDelegate? _ProcessInternal = null;
     private static CallFunctionDelegate? _CallFunction = null;
@@ -143,6 +151,11 @@ internal static class GameFunctions
     public static LoadPackageDelegate LoadPackage =>
         _LoadPackage ??= Marshal.GetDelegateForFunctionPointer<LoadPackageDelegate>(
             MemUtil.GetIntPointer(GameInfo.FuncOffsets.LoadPackage)
+        );
+
+    public static CollectGarbageDelegate CollectGarbage =>
+        _CollectGarbage ??= Marshal.GetDelegateForFunctionPointer<CollectGarbageDelegate>(
+            MemUtil.GetIntPointer(GameInfo.FuncOffsets.CollectGarbage)
         );
 
     public static ProcessEventDelegate ProcessEvent =>

--- a/src/BmSDK/FrameworkInternal/GameInfo.cs
+++ b/src/BmSDK/FrameworkInternal/GameInfo.cs
@@ -27,6 +27,7 @@ internal static class GameInfo
         public const IntPtr StaticFindObject = 0x8ED20;
         public const IntPtr StaticConstructObject = 0x98BE0;
         public const IntPtr LoadPackage = 0x9FCA0;
+        public const IntPtr CollectGarbage = 0xAF0C0;
 
         // UObject (local)
         public const IntPtr ProcessEvent = 0x46A60;

--- a/src/BmSDK/FrameworkInternal/PreloadManager.cs
+++ b/src/BmSDK/FrameworkInternal/PreloadManager.cs
@@ -1,0 +1,69 @@
+using Tomlyn.Model;
+
+namespace BmSDK.Framework;
+
+/// <summary>
+/// Handles mod [preload] sections: loads declared packages, roots declared objects,
+/// and purges any side-effect objects (e.g. stray Levels) via a final GC pass.
+/// </summary>
+internal static class PreloadManager
+{
+    public static void Run()
+    {
+        foreach (var mod in ScriptManager.Mods)
+        {
+            PreloadMod(mod);
+        }
+
+        // Clean up anything we didn't need
+        GameFunctions.CollectGarbage(0, bPerformFullPurge: 1);
+    }
+
+    private static void PreloadMod(Mod mod)
+    {
+        if (!mod.Config.TryGetValue("preload", out var preloadObj)
+            || preloadObj is not TomlTable preload)
+        {
+            return;
+        }
+
+        if (preload.TryGetValue("packages", out var pkgsObj) && pkgsObj is TomlArray pkgs)
+        {
+            foreach (var entry in pkgs)
+            {
+                if (entry is not string pkgName)
+                {
+                    continue;
+                }
+
+                var loaded = Game.LoadPackage(pkgName);
+                if (loaded is null || !loaded.IsValid)
+                {
+                    Debug.LogWarning($"[{mod.Name}] Preload: failed to load package '{pkgName}'");
+                }
+            }
+        }
+
+        if (preload.TryGetValue("keep_alive", out var keepObj) && keepObj is TomlArray keepAlives)
+        {
+            foreach (var entry in keepAlives)
+            {
+                if (entry is not string path)
+                {
+                    continue;
+                }
+
+                var obj = Game.FindObject<GameObject>(path);
+                if (obj is null || !obj.IsValid)
+                {
+                    Debug.LogWarning(
+                        $"[{mod.Name}] Preload: keep_alive object '{path}' not found"
+                    );
+                    continue;
+                }
+
+                obj.AddToRoot();
+            }
+        }
+    }
+}

--- a/src/BmSDK/FrameworkInternal/ScriptManager.cs
+++ b/src/BmSDK/FrameworkInternal/ScriptManager.cs
@@ -66,6 +66,8 @@ internal static class ScriptManager
 
     public static IEnumerable<Script> Scripts => s_loadedMods.Values.SelectMany(m => m.Scripts);
 
+    public static IEnumerable<Mod> Mods => s_loadedMods.Values.Select(m => m.Mod);
+
     private static bool s_isInitialized = false;
 
     /// <summary>

--- a/src/BmSDK/Loader.cs
+++ b/src/BmSDK/Loader.cs
@@ -95,6 +95,9 @@ internal static class Loader
             // Notify scripts of game init
             if (!s_hasGameInited && funcName == InitFuncName)
             {
+                // Preload packages and root keep-alive objects before any world loads
+                PreloadManager.Run();
+
                 ScriptManager.Scripts.ForEach(script =>
                     Debug.RunWithSender(script.Name, script.Main)
                 );


### PR DESCRIPTION
Adds a preload pass that runs before the world loads, making it possible to specify objects in `mod.toml` that are kept alive forever (ported over from `etkramer/dev-mode`)

```toml
[preload]
packages = ["OW_A9_Ch1z"]
keep_alive = ["Batwing_Vehicle.Batwing.Batwing_NEW_SKY"]
```