### PR TITLE
fix: generate enums with underlying type byte

### DIFF
--- a/src/BmSDK.Generator/Printer/Printer.cpp
+++ b/src/BmSDK.Generator/Printer/Printer.cpp
@@ -405,7 +405,7 @@ void Printer::PrintEnum(UEnum* _enum, ostream& out)
     Printer::Indent(out) << "/// </summary>" << endl;
 
     // Print prop declaration
-    Printer::Indent(out) << "public enum " << _enum->GetNameManaged() << endl;
+    Printer::Indent(out) << "public enum " << _enum->GetNameManaged() << " : byte" << endl;
 
     // Print prop body
     Printer::Indent(out) << "{" << endl;

--- a/src/BmSDK/Generated/AkAudio/AkMultipointEmitter.g.cs
+++ b/src/BmSDK/Generated/AkAudio/AkMultipointEmitter.g.cs
@@ -433,7 +433,7 @@ public partial class AkMultipointEmitter : BmSDK.AkAudio.AkEmitter, BmSDK.IGameO
     /// <summary>
     /// Enum: EMultipointEmitterType
     /// </summary>
-    public enum EMultipointEmitterType
+    public enum EMultipointEmitterType : byte
     {
         MULTIPOINT_ADDITIVE = 0,
         MULTIPOINT_POSITIONAL = 1,

--- a/src/BmSDK/Generated/AkAudio/SeqAct_AkComponentSettings.g.cs
+++ b/src/BmSDK/Generated/AkAudio/SeqAct_AkComponentSettings.g.cs
@@ -342,7 +342,7 @@ public partial class SeqAct_AkComponentSettings : BmSDK.Engine.SequenceAction, B
     /// <summary>
     /// Enum: EAkComponentSettingsBool
     /// </summary>
-    public enum EAkComponentSettingsBool
+    public enum EAkComponentSettingsBool : byte
     {
         AK_SETTING_UNCHANGED = 0,
         AK_SETTING_TRUE = 1,

--- a/src/BmSDK/Generated/AkAudio/SeqAct_AkMusicSync.g.cs
+++ b/src/BmSDK/Generated/AkAudio/SeqAct_AkMusicSync.g.cs
@@ -126,7 +126,7 @@ public partial class SeqAct_AkMusicSync : BmSDK.Engine.SequenceAction, BmSDK.IGa
     /// <summary>
     /// Enum: EMusicSyncOutputs
     /// </summary>
-    public enum EMusicSyncOutputs
+    public enum EMusicSyncOutputs : byte
     {
         MUSIC_SYNC_STOPPED = 0,
         MUSIC_SYNC_STARTED = 1,

--- a/src/BmSDK/Generated/BmGame/AlertInstance.g.cs
+++ b/src/BmSDK/Generated/BmGame/AlertInstance.g.cs
@@ -228,7 +228,7 @@ public partial class AlertInstance : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: VisibilityCategory
     /// </summary>
-    public enum VisibilityCategory
+    public enum VisibilityCategory : byte
     {
         VISCat_None = 0,
         VISCat_Suspect = 1,
@@ -241,7 +241,7 @@ public partial class AlertInstance : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: InterruptType
     /// </summary>
-    public enum InterruptType
+    public enum InterruptType : byte
     {
         IN_Blank = 0,
         IN_Noise = 1,

--- a/src/BmSDK/Generated/BmGame/RAEC_Attack_Converge.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAEC_Attack_Converge.g.cs
@@ -319,7 +319,7 @@ public partial class RAEC_Attack_Converge : BmSDK.BmGame.RAEC_SubGroup, BmSDK.IG
     /// <summary>
     /// Enum: ConvergeProcessState
     /// </summary>
-    public enum ConvergeProcessState
+    public enum ConvergeProcessState : byte
     {
         CPS_Begin = 0,
         CPS_APS = 1,

--- a/src/BmSDK/Generated/BmGame/RAEC_Casualty.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAEC_Casualty.g.cs
@@ -395,7 +395,7 @@ public partial class RAEC_Casualty : BmSDK.BmGame.RAEC_CasualtyBase, BmSDK.IGame
     /// <summary>
     /// Enum: NervousSetPieceType
     /// </summary>
-    public enum NervousSetPieceType
+    public enum NervousSetPieceType : byte
     {
         NST_Normal = 0,
         NST_TerrorTrans = 1,

--- a/src/BmSDK/Generated/BmGame/RAEC_Search_Sub_Thermal.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAEC_Search_Sub_Thermal.g.cs
@@ -141,7 +141,7 @@ public partial class RAEC_Search_Sub_Thermal : BmSDK.BmGame.RAEC_Search_Sub, BmS
     /// <summary>
     /// Enum: VantageSearchResult
     /// </summary>
-    public enum VantageSearchResult
+    public enum VantageSearchResult : byte
     {
         VSR_TotalFail = 0,
         VSR_Retry = 1,

--- a/src/BmSDK/Generated/BmGame/RAimingConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAimingConfig.g.cs
@@ -81,7 +81,7 @@ public partial class RAimingConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAimingReference
     /// </summary>
-    public enum EAimingReference
+    public enum EAimingReference : byte
     {
         AR_Forward = 0,
         AR_Head = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimConfig.g.cs
@@ -361,7 +361,7 @@ public partial class RAnimConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAdditiveSubtractMode
     /// </summary>
-    public enum EAdditiveSubtractMode
+    public enum EAdditiveSubtractMode : byte
     {
         ASM_FirstFrame = 0,
         ASM_LastFrame = 1,
@@ -371,7 +371,7 @@ public partial class RAnimConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EYesNoDefault
     /// </summary>
-    public enum EYesNoDefault
+    public enum EYesNoDefault : byte
     {
         YND_Default = 0,
         YND_Yes = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_BeginEnd.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_BeginEnd.g.cs
@@ -85,7 +85,7 @@ public partial class RAnimNotify_BeginEnd : BmSDK.Engine.AnimNotify, BmSDK.IGame
     /// <summary>
     /// Enum: EBeginEndType
     /// </summary>
-    public enum EBeginEndType
+    public enum EBeginEndType : byte
     {
         BET_Begin = 0,
         BET_End = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_Camera.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_Camera.g.cs
@@ -108,7 +108,7 @@ public partial class RAnimNotify_Camera : BmSDK.Engine.AnimNotify, BmSDK.IGameOb
     /// <summary>
     /// Enum: CamNotifyType
     /// </summary>
-    public enum CamNotifyType
+    public enum CamNotifyType : byte
     {
         CNT_None = 0,
         CNT_SetGameSpeed = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_CurveFloat.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_CurveFloat.g.cs
@@ -108,7 +108,7 @@ public partial class RAnimNotify_CurveFloat : BmSDK.Engine.AnimNotify, BmSDK.IGa
     /// <summary>
     /// Enum: EFloatControlType
     /// </summary>
-    public enum EFloatControlType
+    public enum EFloatControlType : byte
     {
         FCC_Set = 0,
         FCC_LinearInterpolate = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_Emote.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_Emote.g.cs
@@ -90,7 +90,7 @@ public partial class RAnimNotify_Emote : BmSDK.BmGame.RAnimNotify_Script, BmSDK.
     /// <summary>
     /// Enum: EEmoteType
     /// </summary>
-    public enum EEmoteType
+    public enum EEmoteType : byte
     {
         Emote_Dazed = 0,
         Emote_ExertLight = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_FootPassing.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_FootPassing.g.cs
@@ -90,7 +90,7 @@ public partial class RAnimNotify_FootPassing : BmSDK.Engine.AnimNotify, BmSDK.IG
     /// <summary>
     /// Enum: EFootPassing
     /// </summary>
-    public enum EFootPassing
+    public enum EFootPassing : byte
     {
         FOOTPASSING_Left = 0,
         FOOTPASSING_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_Footstep.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_Footstep.g.cs
@@ -108,7 +108,7 @@ public partial class RAnimNotify_Footstep : BmSDK.Engine.AnimNotify, BmSDK.IGame
     /// <summary>
     /// Enum: EFootstepSurfaceFinder
     /// </summary>
-    public enum EFootstepSurfaceFinder
+    public enum EFootstepSurfaceFinder : byte
     {
         FSF_Auto = 0,
         FSF_Floor = 1,
@@ -121,7 +121,7 @@ public partial class RAnimNotify_Footstep : BmSDK.Engine.AnimNotify, BmSDK.IGame
     /// <summary>
     /// Enum: EContactType
     /// </summary>
-    public enum EContactType
+    public enum EContactType : byte
     {
         Contact_Normal = 0,
         Contact_Land = 1,
@@ -151,7 +151,7 @@ public partial class RAnimNotify_Footstep : BmSDK.Engine.AnimNotify, BmSDK.IGame
     /// <summary>
     /// Enum: EFoot
     /// </summary>
-    public enum EFoot
+    public enum EFoot : byte
     {
         Foot_Left = 0,
         Foot_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_IK.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_IK.g.cs
@@ -85,7 +85,7 @@ public partial class RAnimNotify_IK : BmSDK.Engine.AnimNotify, BmSDK.IGameObject
     /// <summary>
     /// Enum: EIKHand
     /// </summary>
-    public enum EIKHand
+    public enum EIKHand : byte
     {
         IKH_Left = 0,
         IKH_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_MeetingPoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_MeetingPoint.g.cs
@@ -188,7 +188,7 @@ public partial class RAnimNotify_MeetingPoint : BmSDK.Engine.AnimNotify, BmSDK.I
     /// <summary>
     /// Enum: EMeetingPointType
     /// </summary>
-    public enum EMeetingPointType
+    public enum EMeetingPointType : byte
     {
         MPT_End = 0,
         MPT_Begin = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_MotionExtractionType.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_MotionExtractionType.g.cs
@@ -90,7 +90,7 @@ public partial class RAnimNotify_MotionExtractionType : BmSDK.Engine.AnimNotify,
     /// <summary>
     /// Enum: EMotionExtractionType
     /// </summary>
-    public enum EMotionExtractionType
+    public enum EMotionExtractionType : byte
     {
         MET_CentreOfMass = 0,
         MET_Pelvis = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_SpawnParticleFX.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_SpawnParticleFX.g.cs
@@ -180,7 +180,7 @@ public partial class RAnimNotify_SpawnParticleFX : BmSDK.Engine.AnimNotify, BmSD
     /// <summary>
     /// Enum: BoneOrSocketSource
     /// </summary>
-    public enum BoneOrSocketSource
+    public enum BoneOrSocketSource : byte
     {
         BOSS_Bone = 0,
         BOSS_Socket = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_TouchWire.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_TouchWire.g.cs
@@ -81,7 +81,7 @@ public partial class RAnimNotify_TouchWire : BmSDK.Engine.AnimNotify, BmSDK.IGam
     /// <summary>
     /// Enum: LimbOnOrOff
     /// </summary>
-    public enum LimbOnOrOff
+    public enum LimbOnOrOff : byte
     {
         LIMB_On = 0,
         LIMB_Off = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimNotify_WhipTarget.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimNotify_WhipTarget.g.cs
@@ -108,7 +108,7 @@ public partial class RAnimNotify_WhipTarget : BmSDK.Engine.AnimNotify, BmSDK.IGa
     /// <summary>
     /// Enum: WhipTargetingType
     /// </summary>
-    public enum WhipTargetingType
+    public enum WhipTargetingType : byte
     {
         WhipTargeting_Instantaneous = 0,
         WhipTargeting_Continuous = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil.g.cs
@@ -396,7 +396,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFootSyncPoint
     /// </summary>
-    public enum EFootSyncPoint
+    public enum EFootSyncPoint : byte
     {
         FSP_LeftDown = 0,
         FSP_RightPassing = 1,
@@ -569,7 +569,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFuzziness
     /// </summary>
-    public enum EFuzziness
+    public enum EFuzziness : byte
     {
         FUZZ_Exact = 0,
         FUZZ_Fuzzy = 1,
@@ -739,7 +739,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMirrorChoice
     /// </summary>
-    public enum EMirrorChoice
+    public enum EMirrorChoice : byte
     {
         MC_Automatic = 0,
         MC_Yes = 1,
@@ -750,7 +750,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERootBoneSubtractionMode
     /// </summary>
-    public enum ERootBoneSubtractionMode
+    public enum ERootBoneSubtractionMode : byte
     {
         RBSM_None = 0,
         RBSM_SubtractFirstFrame = 1,
@@ -1109,7 +1109,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBodyPart
     /// </summary>
-    public enum EBodyPart
+    public enum EBodyPart : byte
     {
         BP_UpperBody = 0,
         BP_LowerBody = 1,
@@ -1119,7 +1119,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAbsoluteOrRelative
     /// </summary>
-    public enum EAbsoluteOrRelative
+    public enum EAbsoluteOrRelative : byte
     {
         AOR_Absolute = 0,
         AOR_Relative = 1,
@@ -1520,7 +1520,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERagdollSoundType
     /// </summary>
-    public enum ERagdollSoundType
+    public enum ERagdollSoundType : byte
     {
         RST_Unknown = 0,
         RST_Generic = 1,
@@ -1532,7 +1532,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOptionalCharacterBone
     /// </summary>
-    public enum EOptionalCharacterBone
+    public enum EOptionalCharacterBone : byte
     {
         OCB_Spine3 = 0,
         OCB_Neck1 = 1,
@@ -1544,7 +1544,7 @@ public partial class RAnimUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECharacterBone
     /// </summary>
-    public enum ECharacterBone
+    public enum ECharacterBone : byte
     {
         CB_Bip01 = 0,
         CB_Pelvis = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_FaceFXOutput.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_FaceFXOutput.g.cs
@@ -142,7 +142,7 @@ public partial class RAnimUtil_FaceFXOutput : BmSDK.GameObject, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EBlinkSequenceState
     /// </summary>
-    public enum EBlinkSequenceState
+    public enum EBlinkSequenceState : byte
     {
         BSS_Waiting = 0,
         BSS_PreBlink = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_FloorCorrection.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_FloorCorrection.g.cs
@@ -443,7 +443,7 @@ public partial class RAnimUtil_FloorCorrection : BmSDK.GameObject, BmSDK.IGameOb
     /// <summary>
     /// Enum: EFloorCorrectionInput
     /// </summary>
-    public enum EFloorCorrectionInput
+    public enum EFloorCorrectionInput : byte
     {
         FCI_NotWalking = 0,
         FCI_PawnFloor = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_IKHandOutput.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_IKHandOutput.g.cs
@@ -199,7 +199,7 @@ public partial class RAnimUtil_IKHandOutput : BmSDK.GameObject, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EIKHAnd_PerHandState
     /// </summary>
-    public enum EIKHAnd_PerHandState
+    public enum EIKHAnd_PerHandState : byte
     {
         IKHPHS_Inactive = 0,
         IKHPHS_Lock = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_MovementPlayer.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_MovementPlayer.g.cs
@@ -243,7 +243,7 @@ public partial class RAnimUtil_MovementPlayer : BmSDK.GameObject, BmSDK.IGameObj
     /// <summary>
     /// Enum: EOneShotMovementCycleState
     /// </summary>
-    public enum EOneShotMovementCycleState
+    public enum EOneShotMovementCycleState : byte
     {
         OSMCS_Inactive = 0,
         OSMCS_Waiting = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_PhysicsOutput.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_PhysicsOutput.g.cs
@@ -520,7 +520,7 @@ public partial class RAnimUtil_PhysicsOutput : BmSDK.GameObject, BmSDK.IGameObje
     /// <summary>
     /// Enum: ERagdollTransitionInstigator
     /// </summary>
-    public enum ERagdollTransitionInstigator
+    public enum ERagdollTransitionInstigator : byte
     {
         RTI_Stack = 0,
         RTI_Notify = 1,
@@ -643,7 +643,7 @@ public partial class RAnimUtil_PhysicsOutput : BmSDK.GameObject, BmSDK.IGameObje
     /// <summary>
     /// Enum: ERagdollForceType
     /// </summary>
-    public enum ERagdollForceType
+    public enum ERagdollForceType : byte
     {
         FORCETYPE_Force = 0,
         FORCETYPE_Impulse = 1,

--- a/src/BmSDK/Generated/BmGame/RAnimUtil_PosePlayer.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAnimUtil_PosePlayer.g.cs
@@ -2244,7 +2244,7 @@ public partial class RAnimUtil_PosePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESlavedTransitionTimeSync
     /// </summary>
-    public enum ESlavedTransitionTimeSync
+    public enum ESlavedTransitionTimeSync : byte
     {
         STTS_None = 0,
         STTS_SyncToStart = 1,
@@ -2686,7 +2686,7 @@ public partial class RAnimUtil_PosePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETurnInstigator
     /// </summary>
-    public enum ETurnInstigator
+    public enum ETurnInstigator : byte
     {
         TI_AimAt = 0,
         TI_FaceAt = 1,
@@ -2697,7 +2697,7 @@ public partial class RAnimUtil_PosePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimIdleType
     /// </summary>
-    public enum EAnimIdleType
+    public enum EAnimIdleType : byte
     {
         IDLE_Normal = 0,
         IDLE_Relative = 1,
@@ -2708,7 +2708,7 @@ public partial class RAnimUtil_PosePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimTransitionType
     /// </summary>
-    public enum EAnimTransitionType
+    public enum EAnimTransitionType : byte
     {
         TRANSITION_Normal = 0,
         TRANSITION_Absolute = 1,

--- a/src/BmSDK/Generated/BmGame/RAttackEdgeSearch.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAttackEdgeSearch.g.cs
@@ -180,7 +180,7 @@ public partial class RAttackEdgeSearch : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: AttackEdgeSearchState
     /// </summary>
-    public enum AttackEdgeSearchState
+    public enum AttackEdgeSearchState : byte
     {
         EAES_None = 0,
         EAES_BuildList = 1,

--- a/src/BmSDK/Generated/BmGame/RAttackPointSearch.g.cs
+++ b/src/BmSDK/Generated/BmGame/RAttackPointSearch.g.cs
@@ -196,7 +196,7 @@ public partial class RAttackPointSearch : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: StanceVisType
     /// </summary>
-    public enum StanceVisType
+    public enum StanceVisType : byte
     {
         SVT_Both = 0,
         SVT_StandOnly = 1,
@@ -207,7 +207,7 @@ public partial class RAttackPointSearch : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: AttackPointSearchState
     /// </summary>
-    public enum AttackPointSearchState
+    public enum AttackPointSearchState : byte
     {
         EAPS_None = 0,
         EAPS_StartSearch = 1,

--- a/src/BmSDK/Generated/BmGame/RBM2Behaviour_IdleConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBM2Behaviour_IdleConfig.g.cs
@@ -1794,7 +1794,7 @@ public partial class RBM2Behaviour_IdleConfig : BmSDK.BmGame.RBMBehaviour_MoveTo
     /// <summary>
     /// Enum: TransitionInInteruptSetting
     /// </summary>
-    public enum TransitionInInteruptSetting
+    public enum TransitionInInteruptSetting : byte
     {
         TRANSININTSET_None = 0,
         TRANSININTSET_Replay = 1,
@@ -1806,7 +1806,7 @@ public partial class RBM2Behaviour_IdleConfig : BmSDK.BmGame.RBMBehaviour_MoveTo
     /// <summary>
     /// Enum: EStasisType
     /// </summary>
-    public enum EStasisType
+    public enum EStasisType : byte
     {
         STASIS_AllowStasisWhenNotTransitioning = 0,
         STASIS_AlwaysAllowStasis = 1,

--- a/src/BmSDK/Generated/BmGame/RBM2IdleConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBM2IdleConfig.g.cs
@@ -142,7 +142,7 @@ public partial class RBM2IdleConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: EInterrogationPose
     /// </summary>
-    public enum EInterrogationPose
+    public enum EInterrogationPose : byte
     {
         INTERROG_Standing = 0,
         INTERROG_Wall = 1,
@@ -156,7 +156,7 @@ public partial class RBM2IdleConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: BM2RelativeTransitionStyle
     /// </summary>
-    public enum BM2RelativeTransitionStyle
+    public enum BM2RelativeTransitionStyle : byte
     {
         BM2RTS_None = 0,
         BM2RTS_Prop = 1,

--- a/src/BmSDK/Generated/BmGame/RBMAIAction.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMAIAction.g.cs
@@ -416,7 +416,7 @@ public partial class RBMAIAction : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ActionTickResult
     /// </summary>
-    public enum ActionTickResult
+    public enum ActionTickResult : byte
     {
         ATR_Continue = 0,
         ATR_Finish = 1,
@@ -427,7 +427,7 @@ public partial class RBMAIAction : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ActionExitLevel
     /// </summary>
-    public enum ActionExitLevel
+    public enum ActionExitLevel : byte
     {
         AEL_None = 0,
         AEL_Smooth = 1,

--- a/src/BmSDK/Generated/BmGame/RBMAIAction_CrouchByCasualty.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMAIAction_CrouchByCasualty.g.cs
@@ -233,7 +233,7 @@ public partial class RBMAIAction_CrouchByCasualty : BmSDK.BmGame.RBMAIAction, Bm
     /// <summary>
     /// Enum: CheckManDown_OverlayState
     /// </summary>
-    public enum CheckManDown_OverlayState
+    public enum CheckManDown_OverlayState : byte
     {
         CMD_Any = 0,
         CMD_FaceDown = 1,

--- a/src/BmSDK/Generated/BmGame/RBMAIAction_SniperSearch.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMAIAction_SniperSearch.g.cs
@@ -277,7 +277,7 @@ public partial class RBMAIAction_SniperSearch : BmSDK.BmGame.RBMAIAction, BmSDK.
     /// <summary>
     /// Enum: FireState
     /// </summary>
-    public enum FireState
+    public enum FireState : byte
     {
         FS_Reload = 0,
         FS_Wait = 1,

--- a/src/BmSDK/Generated/BmGame/RBMAIController.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMAIController.g.cs
@@ -2184,7 +2184,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: CasualtyScreamReason
     /// </summary>
-    public enum CasualtyScreamReason
+    public enum CasualtyScreamReason : byte
     {
         CSR_Generic = 0,
         CSR_Fell = 1,
@@ -2198,7 +2198,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: BRAECReactionType
     /// </summary>
-    public enum BRAECReactionType
+    public enum BRAECReactionType : byte
     {
         BRAEC_Batarang = 0,
         BRAEC_SteerableBatarang = 1,
@@ -2211,7 +2211,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: FOVcategory
     /// </summary>
-    public enum FOVcategory
+    public enum FOVcategory : byte
     {
         FOV_None = 0,
         FOV_Peripheral = 1,
@@ -2222,7 +2222,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: BarkType
     /// </summary>
-    public enum BarkType
+    public enum BarkType : byte
     {
         BARK_SPOTTED = 0,
         BARK_SPOTTEDCHASE = 1,
@@ -2333,7 +2333,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: BatmanGrabType
     /// </summary>
-    public enum BatmanGrabType
+    public enum BatmanGrabType : byte
     {
         BGT_NoGrab = 0,
         BGT_Grab = 1,
@@ -2344,7 +2344,7 @@ public partial class RBMAIController : BmSDK.Engine.AIController, BmSDK.IGameObj
     /// <summary>
     /// Enum: PoseMirroredBehaviour
     /// </summary>
-    public enum PoseMirroredBehaviour
+    public enum PoseMirroredBehaviour : byte
     {
         PMB_DontCare = 0,
         PMB_NotMirrored = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviourAutoStringUp.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviourAutoStringUp.g.cs
@@ -400,7 +400,7 @@ public partial class RBMBehaviourAutoStringUp : BmSDK.BmGame.RBMBehaviour, BmSDK
     /// <summary>
     /// Enum: StringUpBones
     /// </summary>
-    public enum StringUpBones
+    public enum StringUpBones : byte
     {
         SUB_LeftFoot = 0,
         SUB_RightFoot = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_Combat.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_Combat.g.cs
@@ -788,7 +788,7 @@ public partial class RBMBehaviour_Combat : BmSDK.BmGame.RBMBehaviour_Controlled,
     /// <summary>
     /// Enum: MoveForceWallDir
     /// </summary>
-    public enum MoveForceWallDir
+    public enum MoveForceWallDir : byte
     {
         WALL_Left = 0,
         WALL_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_CombatAI.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_CombatAI.g.cs
@@ -704,7 +704,7 @@ public partial class RBMBehaviour_CombatAI : BmSDK.BmGame.RBMBehaviour_Combat, B
     /// <summary>
     /// Enum: NoMoveReason
     /// </summary>
-    public enum NoMoveReason
+    public enum NoMoveReason : byte
     {
         NMR_None = 0,
         NMR_NoFloor = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_CombatRas.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_CombatRas.g.cs
@@ -523,7 +523,7 @@ public partial class RBMBehaviour_CombatRas : BmSDK.BmGame.RBMBehaviour_CombatAI
     /// <summary>
     /// Enum: ESwordClusterLevel
     /// </summary>
-    public enum ESwordClusterLevel
+    public enum ESwordClusterLevel : byte
     {
         SCL_Easy = 0,
         SCL_Medium = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_Follow.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_Follow.g.cs
@@ -170,7 +170,7 @@ public partial class RBMBehaviour_Follow : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: MoveSpeed
     /// </summary>
-    public enum MoveSpeed
+    public enum MoveSpeed : byte
     {
         MOVESPEED_Walk = 0,
         MOVESPEED_Run = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_HitReaction.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_HitReaction.g.cs
@@ -312,7 +312,7 @@ public partial class RBMBehaviour_HitReaction : BmSDK.BmGame.RBMBehaviour, BmSDK
     /// <summary>
     /// Enum: HitAnimType
     /// </summary>
-    public enum HitAnimType
+    public enum HitAnimType : byte
     {
         HTY_Left = 0,
         HTY_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_Idle.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_Idle.g.cs
@@ -194,7 +194,7 @@ public partial class RBMBehaviour_Idle : BmSDK.BmGame.RBMBehaviour, BmSDK.IGameO
     /// <summary>
     /// Enum: MirrorState
     /// </summary>
-    public enum MirrorState
+    public enum MirrorState : byte
     {
         MS_RandomMirroring = 0,
         MS_NoMirroring = 1,
@@ -205,7 +205,7 @@ public partial class RBMBehaviour_Idle : BmSDK.BmGame.RBMBehaviour, BmSDK.IGameO
     /// <summary>
     /// Enum: CommonPoses
     /// </summary>
-    public enum CommonPoses
+    public enum CommonPoses : byte
     {
         CP_Current = 0,
         CP_Standing = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToBase.g.cs
@@ -167,7 +167,7 @@ public partial class RBMBehaviour_MoveToBase : BmSDK.BmGame.RBMBehaviour, BmSDK.
     /// <summary>
     /// Enum: MoveToSpeed
     /// </summary>
-    public enum MoveToSpeed
+    public enum MoveToSpeed : byte
     {
         MOVETOSPEED_Walk = 0,
         MOVETOSPEED_Run = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToNavMesh.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToNavMesh.g.cs
@@ -273,7 +273,7 @@ public partial class RBMBehaviour_MoveToNavMesh : BmSDK.BmGame.RBMBehaviour, BmS
     /// <summary>
     /// Enum: MoveToSpeed
     /// </summary>
-    public enum MoveToSpeed
+    public enum MoveToSpeed : byte
     {
         MOVETOSPEED_Walk = 0,
         MOVETOSPEED_Run = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToRandomPoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_MoveToRandomPoint.g.cs
@@ -183,7 +183,7 @@ public partial class RBMBehaviour_MoveToRandomPoint : BmSDK.BmGame.RBMBehaviour,
     /// <summary>
     /// Enum: MoveToSpeed
     /// </summary>
-    public enum MoveToSpeed
+    public enum MoveToSpeed : byte
     {
         MOVETOSPEED_Walk = 0,
         MOVETOSPEED_Run = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_SetIdleStance.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_SetIdleStance.g.cs
@@ -111,7 +111,7 @@ public partial class RBMBehaviour_SetIdleStance : BmSDK.BmGame.RBMBehaviour, BmS
     /// <summary>
     /// Enum: IdleStanceName
     /// </summary>
-    public enum IdleStanceName
+    public enum IdleStanceName : byte
     {
         ISN_Random = 0,
         ISN_None = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_Sniper.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_Sniper.g.cs
@@ -702,7 +702,7 @@ public partial class RBMBehaviour_Sniper : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: FireState
     /// </summary>
-    public enum FireState
+    public enum FireState : byte
     {
         FS_Reload = 0,
         FS_Wait = 1,

--- a/src/BmSDK/Generated/BmGame/RBMBehaviour_Venom.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMBehaviour_Venom.g.cs
@@ -445,7 +445,7 @@ public partial class RBMBehaviour_Venom : BmSDK.BmGame.RBMBehaviour_Combat, BmSD
     /// <summary>
     /// Enum: LastStrikeSide
     /// </summary>
-    public enum LastStrikeSide
+    public enum LastStrikeSide : byte
     {
         LSS_None = 0,
         LSS_Left = 1,
@@ -456,7 +456,7 @@ public partial class RBMBehaviour_Venom : BmSDK.BmGame.RBMBehaviour_Combat, BmSD
     /// <summary>
     /// Enum: BeatUpStages
     /// </summary>
-    public enum BeatUpStages
+    public enum BeatUpStages : byte
     {
         BUS_Stage1 = 0,
         BUS_Stage2 = 1,

--- a/src/BmSDK/Generated/BmGame/RBMCombatDamageProxy.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMCombatDamageProxy.g.cs
@@ -200,7 +200,7 @@ public partial class RBMCombatDamageProxy : BmSDK.Engine.Actor, BmSDK.IGameObjec
     /// <summary>
     /// Enum: DamageDirectionType
     /// </summary>
-    public enum DamageDirectionType
+    public enum DamageDirectionType : byte
     {
         DD_Parallel = 0,
         DD_Perpendicular = 1,

--- a/src/BmSDK/Generated/BmGame/RBMCombatManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMCombatManager.g.cs
@@ -2060,7 +2060,7 @@ public partial class RBMCombatManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EVenomDifficultyType
     /// </summary>
-    public enum EVenomDifficultyType
+    public enum EVenomDifficultyType : byte
     {
         EVDT_Health = 0,
         EVDT_TakeDamageBatarangLight = 1,
@@ -2156,7 +2156,7 @@ public partial class RBMCombatManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDifficultyType
     /// </summary>
-    public enum EDifficultyType
+    public enum EDifficultyType : byte
     {
         EDT_DamageUnarmed = 0,
         EDT_DamagePipe = 1,
@@ -2203,7 +2203,7 @@ public partial class RBMCombatManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EWeaponConfigType
     /// </summary>
-    public enum EWeaponConfigType
+    public enum EWeaponConfigType : byte
     {
         WEAPONCONFIG_None = 0,
         WEAPONCONFIG_Unarmed = 1,

--- a/src/BmSDK/Generated/BmGame/RBMCutscene_Cam.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMCutscene_Cam.g.cs
@@ -278,7 +278,7 @@ public partial class RBMCutscene_Cam : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: CamMovementTestResults
     /// </summary>
-    public enum CamMovementTestResults
+    public enum CamMovementTestResults : byte
     {
         CMTR_AllFine = 0,
         CMTR_CantMove = 1,

--- a/src/BmSDK/Generated/BmGame/RBMPathNode_VariablePositionTraverse.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMPathNode_VariablePositionTraverse.g.cs
@@ -232,7 +232,7 @@ public partial class RBMPathNode_VariablePositionTraverse : BmSDK.BmGame.RBMPath
     /// <summary>
     /// Enum: FenceJumpEdgeType
     /// </summary>
-    public enum FenceJumpEdgeType
+    public enum FenceJumpEdgeType : byte
     {
         FENCEEDGE_Drop = 0,
         FENCEEDGE_Climb = 1,

--- a/src/BmSDK/Generated/BmGame/RBMPawnAI.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMPawnAI.g.cs
@@ -2290,7 +2290,7 @@ public partial class RBMPawnAI : BmSDK.BmGame.RBMPawnAIAnim, BmSDK.Engine.Interf
     /// <summary>
     /// Enum: GunTargetBoneState
     /// </summary>
-    public enum GunTargetBoneState
+    public enum GunTargetBoneState : byte
     {
         GTBS_Untested = 0,
         GTBS_Obscured = 1,

--- a/src/BmSDK/Generated/BmGame/RBMPawnAIAnim.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMPawnAIAnim.g.cs
@@ -452,7 +452,7 @@ public partial class RBMPawnAIAnim : BmSDK.BmGame.RPawnCombat, BmSDK.BmGame.RXra
     /// <summary>
     /// Enum: XrayType
     /// </summary>
-    public enum XrayType
+    public enum XrayType : byte
     {
         XT_Blue = 0,
         XT_Red = 1,

--- a/src/BmSDK/Generated/BmGame/RBMRoomAIState.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMRoomAIState.g.cs
@@ -864,7 +864,7 @@ public partial class RBMRoomAIState : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: VillainFearLevel
     /// </summary>
-    public enum VillainFearLevel
+    public enum VillainFearLevel : byte
     {
         VFL_Cocky = 0,
         VFL_Nervous = 1,

--- a/src/BmSDK/Generated/BmGame/RBMSpeechManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMSpeechManager.g.cs
@@ -613,7 +613,7 @@ public partial class RBMSpeechManager : BmSDK.Engine.ActorComponent, BmSDK.IGame
     /// <summary>
     /// Enum: InternalSpeakingEnum
     /// </summary>
-    public enum InternalSpeakingEnum
+    public enum InternalSpeakingEnum : byte
     {
         InternalSpeaking_Off = 0,
         InternalSpeaking_FaceFX = 1,

--- a/src/BmSDK/Generated/BmGame/RBMWeapon.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBMWeapon.g.cs
@@ -822,7 +822,7 @@ public partial class RBMWeapon : BmSDK.Engine.Inventory, BmSDK.BmGame.RXrayInter
     /// <summary>
     /// Enum: EHudWeaponType
     /// </summary>
-    public enum EHudWeaponType
+    public enum EHudWeaponType : byte
     {
         HWT_None = 0,
         HWT_Knives = 1,

--- a/src/BmSDK/Generated/BmGame/RBarkSet.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBarkSet.g.cs
@@ -176,7 +176,7 @@ public partial class RBarkSet : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EConvoBarkType
     /// </summary>
-    public enum EConvoBarkType
+    public enum EConvoBarkType : byte
     {
         CBARK_None = 0,
         CBARK_Exclaim = 1,

--- a/src/BmSDK/Generated/BmGame/RBatarangCamera.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBatarangCamera.g.cs
@@ -335,7 +335,7 @@ public partial class RBatarangCamera : BmSDK.BmGame.RCameraActor, BmSDK.IGameObj
     /// <summary>
     /// Enum: BatarangCameraRollingDirection
     /// </summary>
-    public enum BatarangCameraRollingDirection
+    public enum BatarangCameraRollingDirection : byte
     {
         BCRD_NotRolling = 0,
         BCRD_RollingLeft = 1,

--- a/src/BmSDK/Generated/BmGame/RBmBatmanCutscene.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBmBatmanCutscene.g.cs
@@ -104,7 +104,7 @@ public partial class RBmBatmanCutscene : BmSDK.BmGame.RBMCutsceneBase, BmSDK.IGa
     /// <summary>
     /// Enum: BatmanCutsceneType
     /// </summary>
-    public enum BatmanCutsceneType
+    public enum BatmanCutsceneType : byte
     {
         BCT_BatClawCutscene = 0,
         BCT_MultiBatClawCutscene = 1,

--- a/src/BmSDK/Generated/BmGame/RBmPawnSpawner.g.cs
+++ b/src/BmSDK/Generated/BmGame/RBmPawnSpawner.g.cs
@@ -993,7 +993,7 @@ public partial class RBmPawnSpawner : BmSDK.Engine.SeqAct_Latent, BmSDK.IGameObj
     /// <summary>
     /// Enum: EPS_PawnTypes
     /// </summary>
-    public enum EPS_PawnTypes
+    public enum EPS_PawnTypes : byte
     {
         EPS_LEAVEEMPTY = 0,
         EPS_MAX = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeCollisionShapeConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeCollisionShapeConfig.g.cs
@@ -165,7 +165,7 @@ public partial class RCapeCollisionShapeConfig : BmSDK.GameObject, BmSDK.IGameOb
     /// <summary>
     /// Enum: ECollisionShape
     /// </summary>
-    public enum ECollisionShape
+    public enum ECollisionShape : byte
     {
         ECollisionShape_Sphere = 0,
         ECollisionShape_ConvexHull = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeComponent.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeComponent.g.cs
@@ -773,7 +773,7 @@ public partial class RCapeComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: EInitterType
     /// </summary>
-    public enum EInitterType
+    public enum EInitterType : byte
     {
         INITTERTYPE_Batman = 0,
         INITTERTYPE_Phys = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeSkeletalMeshComponent.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeSkeletalMeshComponent.g.cs
@@ -208,7 +208,7 @@ public partial class RCapeSkeletalMeshComponent : BmSDK.Engine.SkeletalMeshCompo
     /// <summary>
     /// Enum: ECapeBoundsCalculationType
     /// </summary>
-    public enum ECapeBoundsCalculationType
+    public enum ECapeBoundsCalculationType : byte
     {
         CAPEBOUNDSCALCULATION_Tight = 0,
         CAPEBOUNDSCALCULATION_Loose = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeStateBoneConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeStateBoneConfig.g.cs
@@ -311,7 +311,7 @@ public partial class RCapeStateBoneConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeBoneSkinningType
     /// </summary>
-    public enum ECapeBoneSkinningType
+    public enum ECapeBoneSkinningType : byte
     {
         CAPEBONESKINNINGTYPE_Full = 0,
         CAPEBONESKINNINGTYPE_TranslationOnly = 1,
@@ -323,7 +323,7 @@ public partial class RCapeStateBoneConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EStateEffectType
     /// </summary>
-    public enum EStateEffectType
+    public enum EStateEffectType : byte
     {
         STATEEFFECT_SingleBone = 0,
         STATEEFFECT_ChainParents = 1,
@@ -335,7 +335,7 @@ public partial class RCapeStateBoneConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeBoneState
     /// </summary>
-    public enum ECapeBoneState
+    public enum ECapeBoneState : byte
     {
         ECAPEBONESTATE_Animated = 0,
         ECAPEBONESTATE_AnimationDriven = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeStateConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeStateConfig.g.cs
@@ -531,7 +531,7 @@ public partial class RCapeStateConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: OverstretchHandlingMethod
     /// </summary>
-    public enum OverstretchHandlingMethod
+    public enum OverstretchHandlingMethod : byte
     {
         OVERSTRETCHHANDLINGMETHOD_Default = 0,
         OVERSTRETCHHANDLINGMETHOD_Simple = 1,
@@ -576,7 +576,7 @@ public partial class RCapeStateConfig : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAutoForwardType
     /// </summary>
-    public enum EAutoForwardType
+    public enum EAutoForwardType : byte
     {
         AUTOFORWARDTYPE_None = 0,
         AUTOFORWARDTYPE_AtEndOfAnim = 1,

--- a/src/BmSDK/Generated/BmGame/RCapeStateController.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCapeStateController.g.cs
@@ -976,7 +976,7 @@ public partial class RCapeStateController : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeBoneVisibility
     /// </summary>
-    public enum ECapeBoneVisibility
+    public enum ECapeBoneVisibility : byte
     {
         CAPEBONEVISIBILITY_Visible = 0,
         CAPEBONEVISIBILITY_Invisible = 1,

--- a/src/BmSDK/Generated/BmGame/RChallengeManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RChallengeManager.g.cs
@@ -872,7 +872,7 @@ public partial class RChallengeManager : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: MapMaskBits
     /// </summary>
-    public enum MapMaskBits
+    public enum MapMaskBits : byte
     {
         eMapMaskBit_Head2Head = 0,
         eMapMaskBit_1P_Only = 1,
@@ -999,7 +999,7 @@ public partial class RChallengeManager : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPlayableCharacters
     /// </summary>
-    public enum EPlayableCharacters
+    public enum EPlayableCharacters : byte
     {
         PLR_Batman = 0,
         PLR_Catwoman = 1,

--- a/src/BmSDK/Generated/BmGame/RChapterLineSet.g.cs
+++ b/src/BmSDK/Generated/BmGame/RChapterLineSet.g.cs
@@ -124,7 +124,7 @@ public partial class RChapterLineSet : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFaction
     /// </summary>
-    public enum EFaction
+    public enum EFaction : byte
     {
         FACTION_None = 0,
         FACTION_All = 1,

--- a/src/BmSDK/Generated/BmGame/RCharacter.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCharacter.g.cs
@@ -226,7 +226,7 @@ public partial class RCharacter : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GangTypeEnum
     /// </summary>
-    public enum GangTypeEnum
+    public enum GangTypeEnum : byte
     {
         GangType_None = 0,
         GangType_Joker = 1,

--- a/src/BmSDK/Generated/BmGame/RChaseLocationSearch.g.cs
+++ b/src/BmSDK/Generated/BmGame/RChaseLocationSearch.g.cs
@@ -302,7 +302,7 @@ public partial class RChaseLocationSearch : BmSDK.BmGame.RSearchTreeFinder, BmSD
     /// <summary>
     /// Enum: ChaseSearchState
     /// </summary>
-    public enum ChaseSearchState
+    public enum ChaseSearchState : byte
     {
         ECSS_None = 0,
         ECSS_WaitingForPaths = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_BatmanFloorTakedown.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_BatmanFloorTakedown.g.cs
@@ -205,7 +205,7 @@ public partial class RCombatMove_BatmanFloorTakedown : BmSDK.BmGame.RCombatMove_
     /// <summary>
     /// Enum: CancelTakedownStatus
     /// </summary>
-    public enum CancelTakedownStatus
+    public enum CancelTakedownStatus : byte
     {
         ECTS_Undefined = 0,
         ECTS_Cancel = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_BatmanThrownObjectCounter.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_BatmanThrownObjectCounter.g.cs
@@ -210,7 +210,7 @@ public partial class RCombatMove_BatmanThrownObjectCounter : BmSDK.BmGame.RComba
     /// <summary>
     /// Enum: CatchAnimType
     /// </summary>
-    public enum CatchAnimType
+    public enum CatchAnimType : byte
     {
         ECAT_VQuick = 0,
         ECAT_Quick = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_NinjaDodgeStrike.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_NinjaDodgeStrike.g.cs
@@ -139,7 +139,7 @@ public partial class RCombatMove_NinjaDodgeStrike : BmSDK.BmGame.RCombatMove, Bm
     /// <summary>
     /// Enum: NinjaDodgeReason
     /// </summary>
-    public enum NinjaDodgeReason
+    public enum NinjaDodgeReason : byte
     {
         DODGE_FarStrike = 0,
         DODGE_ShortStrike = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_RasAttack.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_RasAttack.g.cs
@@ -184,7 +184,7 @@ public partial class RCombatMove_RasAttack : BmSDK.BmGame.RCombatMove_VillainAtt
     /// <summary>
     /// Enum: RasAttackType
     /// </summary>
-    public enum RasAttackType
+    public enum RasAttackType : byte
     {
         RAT_None = 0,
         RAT_Charge = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_VillainAttack.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_VillainAttack.g.cs
@@ -355,7 +355,7 @@ public partial class RCombatMove_VillainAttack : BmSDK.BmGame.RCombatMove, BmSDK
     /// <summary>
     /// Enum: AttackCounterTypes
     /// </summary>
-    public enum AttackCounterTypes
+    public enum AttackCounterTypes : byte
     {
         ACT_Counter = 0,
         ACT_Evade = 1,

--- a/src/BmSDK/Generated/BmGame/RCombatMove_VillainJump.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCombatMove_VillainJump.g.cs
@@ -138,7 +138,7 @@ public partial class RCombatMove_VillainJump : BmSDK.BmGame.RCombatMove, BmSDK.I
     /// <summary>
     /// Enum: EVillainJumpType
     /// </summary>
-    public enum EVillainJumpType
+    public enum EVillainJumpType : byte
     {
         EVJT_Left = 0,
         EVJT_Right = 1,

--- a/src/BmSDK/Generated/BmGame/RControllableChatteringTeethBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RControllableChatteringTeethBase.g.cs
@@ -368,7 +368,7 @@ public partial class RControllableChatteringTeethBase : BmSDK.Engine.Pawn, BmSDK
     /// <summary>
     /// Enum: EExplosionOutcome
     /// </summary>
-    public enum EExplosionOutcome
+    public enum EExplosionOutcome : byte
     {
         EXPLOSIONOUTCOME_NotExploded = 0,
         EXPLOSIONOUTCOME_None = 1,
@@ -380,7 +380,7 @@ public partial class RControllableChatteringTeethBase : BmSDK.Engine.Pawn, BmSDK
     /// <summary>
     /// Enum: EChatteringTeethState
     /// </summary>
-    public enum EChatteringTeethState
+    public enum EChatteringTeethState : byte
     {
         CHATTERINGTEETHSTATE_Walking = 0,
         CHATTERINGTEETHSTATE_TriggerExplode = 1,

--- a/src/BmSDK/Generated/BmGame/RCornerPointBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCornerPointBase.g.cs
@@ -258,7 +258,7 @@ public partial class RCornerPointBase : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: AmbushDir
     /// </summary>
-    public enum AmbushDir
+    public enum AmbushDir : byte
     {
         AMB_NONE = 0,
         AMB_LEFT = 1,

--- a/src/BmSDK/Generated/BmGame/RCornerWallMarkerBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCornerWallMarkerBase.g.cs
@@ -114,7 +114,7 @@ public partial class RCornerWallMarkerBase : BmSDK.Engine.Actor, BmSDK.IGameObje
     /// <summary>
     /// Enum: BatmanCoverCorners
     /// </summary>
-    public enum BatmanCoverCorners
+    public enum BatmanCoverCorners : byte
     {
         BCC_LeftCorner = 0,
         BCC_RightCorner = 1,
@@ -126,7 +126,7 @@ public partial class RCornerWallMarkerBase : BmSDK.Engine.Actor, BmSDK.IGameObje
     /// <summary>
     /// Enum: CornerState
     /// </summary>
-    public enum CornerState
+    public enum CornerState : byte
     {
         CS_TwoWay = 0,
         CS_DestOnly = 1,

--- a/src/BmSDK/Generated/BmGame/RCrawlSpaceVolume.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCrawlSpaceVolume.g.cs
@@ -157,7 +157,7 @@ public partial class RCrawlSpaceVolume : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: ReverbPreset
     /// </summary>
-    public enum ReverbPreset
+    public enum ReverbPreset : byte
     {
         REVERB_None = 0,
         REVERB_Generic = 1,

--- a/src/BmSDK/Generated/BmGame/RCreeperVineBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCreeperVineBase.g.cs
@@ -95,7 +95,7 @@ public partial class RCreeperVineBase : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EVineState
     /// </summary>
-    public enum EVineState
+    public enum EVineState : byte
     {
         VINESTATE_PreAttack = 0,
         VINESTATE_Attack = 1,

--- a/src/BmSDK/Generated/BmGame/RCwGrappleGunBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RCwGrappleGunBase.g.cs
@@ -1587,7 +1587,7 @@ public partial class RCwGrappleGunBase : BmSDK.BmGame.RGrappleGun, BmSDK.IGameOb
     /// <summary>
     /// Enum: EClawClimbStartMode
     /// </summary>
-    public enum EClawClimbStartMode
+    public enum EClawClimbStartMode : byte
     {
         CCSM_FromGround = 0,
         CCSM_FromWallStick = 1,
@@ -2387,7 +2387,7 @@ public partial class RCwGrappleGunBase : BmSDK.BmGame.RGrappleGun, BmSDK.IGameOb
     /// <summary>
     /// Enum: ClimbPathFailReason
     /// </summary>
-    public enum ClimbPathFailReason
+    public enum ClimbPathFailReason : byte
     {
         CPFR_None = 0,
         CPFR_NoStartPoint = 1,
@@ -2773,7 +2773,7 @@ public partial class RCwGrappleGunBase : BmSDK.BmGame.RGrappleGun, BmSDK.IGameOb
     /// <summary>
     /// Enum: EStartPoints
     /// </summary>
-    public enum EStartPoints
+    public enum EStartPoints : byte
     {
         START_NextToPlayer = 0,
         START_BelowTarget = 1,
@@ -2792,7 +2792,7 @@ public partial class RCwGrappleGunBase : BmSDK.BmGame.RGrappleGun, BmSDK.IGameOb
     /// <summary>
     /// Enum: EClawClimbDirection
     /// </summary>
-    public enum EClawClimbDirection
+    public enum EClawClimbDirection : byte
     {
         CCD_Random = 0,
         CCD_Left = 1,

--- a/src/BmSDK/Generated/BmGame/RDamageType.g.cs
+++ b/src/BmSDK/Generated/BmGame/RDamageType.g.cs
@@ -81,7 +81,7 @@ public partial class RDamageType : BmSDK.Engine.DamageType, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBatmanArmourType
     /// </summary>
-    public enum EBatmanArmourType
+    public enum EBatmanArmourType : byte
     {
         EBA_ArmourMelee = 0,
         EBA_ArmourBallistic = 1,

--- a/src/BmSDK/Generated/BmGame/RDialogueManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RDialogueManager.g.cs
@@ -1277,7 +1277,7 @@ public partial class RDialogueManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: eDialogueFailResponse
     /// </summary>
-    public enum eDialogueFailResponse
+    public enum eDialogueFailResponse : byte
     {
         DF_Unknown = 0,
         DF_Allowed = 1,
@@ -1450,7 +1450,7 @@ public partial class RDialogueManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ePendingErrorType
     /// </summary>
-    public enum ePendingErrorType
+    public enum ePendingErrorType : byte
     {
         PendingError_None = 0,
         PendingError_Bank = 1,
@@ -1461,7 +1461,7 @@ public partial class RDialogueManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ePendingState
     /// </summary>
-    public enum ePendingState
+    public enum ePendingState : byte
     {
         PendingState_Starting = 0,
         PendingState_DebugPrint = 1,
@@ -1671,7 +1671,7 @@ public partial class RDialogueManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ePendingLoadState
     /// </summary>
-    public enum ePendingLoadState
+    public enum ePendingLoadState : byte
     {
         ePendingLoad_PackageLoading = 0,
         ePendingLoad_LoadedPackage = 1,
@@ -1747,7 +1747,7 @@ public partial class RDialogueManager : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: eDialogueDebugNoteState
     /// </summary>
-    public enum eDialogueDebugNoteState
+    public enum eDialogueDebugNoteState : byte
     {
         DDN_Normal = 0,
         DDN_Warning = 1,

--- a/src/BmSDK/Generated/BmGame/RDisruptableInterface.g.cs
+++ b/src/BmSDK/Generated/BmGame/RDisruptableInterface.g.cs
@@ -143,7 +143,7 @@ public partial interface RDisruptableInterface : BmSDK.Interface
     /// <summary>
     /// Enum: DisruptableObjectTargetType
     /// </summary>
-    public enum DisruptableObjectTargetType
+    public enum DisruptableObjectTargetType : byte
     {
         DOTT_AccessDoor = 0,
         DOTT_ElevatorControlCall = 1,
@@ -167,7 +167,7 @@ public partial interface RDisruptableInterface : BmSDK.Interface
     /// <summary>
     /// Enum: DisruptableObjectNetworkType
     /// </summary>
-    public enum DisruptableObjectNetworkType
+    public enum DisruptableObjectNetworkType : byte
     {
         DONT_GothamMunicipalNetwork = 0,
         DONT_TygerMcpMainframe = 1,

--- a/src/BmSDK/Generated/BmGame/RDisruptableObjectBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RDisruptableObjectBase.g.cs
@@ -497,7 +497,7 @@ public partial class RDisruptableObjectBase : BmSDK.Engine.Actor, BmSDK.BmGame.R
     /// <summary>
     /// Enum: DisruptableObjectDifficulty
     /// </summary>
-    public enum DisruptableObjectDifficulty
+    public enum DisruptableObjectDifficulty : byte
     {
         DOD_VeryEasy = 0,
         DOD_Easy = 1,

--- a/src/BmSDK/Generated/BmGame/RDynamicMenu.g.cs
+++ b/src/BmSDK/Generated/BmGame/RDynamicMenu.g.cs
@@ -765,7 +765,7 @@ public partial class RDynamicMenu : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDynamicMenuButton
     /// </summary>
-    public enum EDynamicMenuButton
+    public enum EDynamicMenuButton : byte
     {
         DMB_A = 0,
         DMB_B = 1,

--- a/src/BmSDK/Generated/BmGame/RElectrifiedFloorPanel.g.cs
+++ b/src/BmSDK/Generated/BmGame/RElectrifiedFloorPanel.g.cs
@@ -647,7 +647,7 @@ public partial class RElectrifiedFloorPanel : BmSDK.Engine.StaticMeshActor, BmSD
     /// <summary>
     /// Enum: FloorPanelStates
     /// </summary>
-    public enum FloorPanelStates
+    public enum FloorPanelStates : byte
     {
         EFP_Deactivated = 0,
         EFP_WarmingUp = 1,

--- a/src/BmSDK/Generated/BmGame/REvidence.g.cs
+++ b/src/BmSDK/Generated/BmGame/REvidence.g.cs
@@ -198,7 +198,7 @@ public partial class REvidence : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: DevicePostProcessEffects
     /// </summary>
-    public enum DevicePostProcessEffects
+    public enum DevicePostProcessEffects : byte
     {
         DPPE_Gas = 0,
         DPPE_Xray = 1,

--- a/src/BmSDK/Generated/BmGame/RFlagManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RFlagManager.g.cs
@@ -347,7 +347,7 @@ public partial class RFlagManager : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: RFlagType
     /// </summary>
-    public enum RFlagType
+    public enum RFlagType : byte
     {
         RFlagType_Global = 0,
         RFlagType_Actor = 1,

--- a/src/BmSDK/Generated/BmGame/RForensicsDevice.g.cs
+++ b/src/BmSDK/Generated/BmGame/RForensicsDevice.g.cs
@@ -1029,7 +1029,7 @@ public partial class RForensicsDevice : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: VisualHudMode
     /// </summary>
-    public enum VisualHudMode
+    public enum VisualHudMode : byte
     {
         VHM_NormalView = 0,
         VHM_DetectiveMode = 1,
@@ -1040,7 +1040,7 @@ public partial class RForensicsDevice : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: SpecialTrackingMode
     /// </summary>
-    public enum SpecialTrackingMode
+    public enum SpecialTrackingMode : byte
     {
         SPM_None = 0,
         SPM_Pheromone = 1,
@@ -1054,7 +1054,7 @@ public partial class RForensicsDevice : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: FlashStates
     /// </summary>
-    public enum FlashStates
+    public enum FlashStates : byte
     {
         FlS_Up = 0,
         FlS_Hold = 1,
@@ -1066,7 +1066,7 @@ public partial class RForensicsDevice : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EvidenceDisplayState
     /// </summary>
-    public enum EvidenceDisplayState
+    public enum EvidenceDisplayState : byte
     {
         EDS_ScannerNonScan = 0,
         EDS_Scanner = 1,

--- a/src/BmSDK/Generated/BmGame/RFractureWallBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RFractureWallBase.g.cs
@@ -850,7 +850,7 @@ public partial class RFractureWallBase : BmSDK.Engine.FracturedStaticMeshActor, 
     /// <summary>
     /// Enum: EFractureWallSide
     /// </summary>
-    public enum EFractureWallSide
+    public enum EFractureWallSide : byte
     {
         EFRACTUREWALLSIDE_Front = 0,
         EFRACTUREWALLSIDE_Back = 1,
@@ -860,7 +860,7 @@ public partial class RFractureWallBase : BmSDK.Engine.FracturedStaticMeshActor, 
     /// <summary>
     /// Enum: ERigidBodyCollisionResponseType
     /// </summary>
-    public enum ERigidBodyCollisionResponseType
+    public enum ERigidBodyCollisionResponseType : byte
     {
         RBCR_None = 0,
         RBCR_ForceBreak = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovie.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovie.g.cs
@@ -1067,7 +1067,7 @@ public partial class RGFxMovie : BmSDK.GFxUI.GFxMoviePlayer, BmSDK.IGameObject
     /// <summary>
     /// Enum: FlashAudioChannel
     /// </summary>
-    public enum FlashAudioChannel
+    public enum FlashAudioChannel : byte
     {
         FLASH_AUDIO_CHANNEL_UI = 0,
         FLASH_AUDIO_CHANNEL_HUD = 1,
@@ -1077,7 +1077,7 @@ public partial class RGFxMovie : BmSDK.GFxUI.GFxMoviePlayer, BmSDK.IGameObject
     /// <summary>
     /// Enum: KeyMapping
     /// </summary>
-    public enum KeyMapping
+    public enum KeyMapping : byte
     {
         KeyMapping_None = 0,
         KeyMapping_START = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieBackScreen.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieBackScreen.g.cs
@@ -1903,7 +1903,7 @@ public partial class RGFxMovieBackScreen : BmSDK.BmGame.RGFxMovie, BmSDK.IGameOb
     /// <summary>
     /// Enum: RiddleLoadingStatus
     /// </summary>
-    public enum RiddleLoadingStatus
+    public enum RiddleLoadingStatus : byte
     {
         RLS_None = 0,
         RLS_Package = 1,
@@ -1940,7 +1940,7 @@ public partial class RGFxMovieBackScreen : BmSDK.BmGame.RGFxMovie, BmSDK.IGameOb
     /// <summary>
     /// Enum: UpgradeItemType
     /// </summary>
-    public enum UpgradeItemType
+    public enum UpgradeItemType : byte
     {
         UIT_Batsuit = 0,
         UIT_Gadgets = 1,
@@ -1953,7 +1953,7 @@ public partial class RGFxMovieBackScreen : BmSDK.BmGame.RGFxMovie, BmSDK.IGameOb
     /// <summary>
     /// Enum: BackScreenType
     /// </summary>
-    public enum BackScreenType
+    public enum BackScreenType : byte
     {
         BST_Upgrade = 0,
         BST_Map = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieChallengeHUD.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieChallengeHUD.g.cs
@@ -1218,7 +1218,7 @@ public partial class RGFxMovieChallengeHUD : BmSDK.BmGame.RGFxMovie, BmSDK.IGame
     /// <summary>
     /// Enum: ChallengeModeEnum
     /// </summary>
-    public enum ChallengeModeEnum
+    public enum ChallengeModeEnum : byte
     {
         ChM_Unspecified = 0,
         ChM_Predator = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieFrontMost.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieFrontMost.g.cs
@@ -454,7 +454,7 @@ public partial class RGFxMovieFrontMost : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObj
     /// <summary>
     /// Enum: SubtitleJustify
     /// </summary>
-    public enum SubtitleJustify
+    public enum SubtitleJustify : byte
     {
         SUBS_LeftAlign = 0,
         SUBS_Centered = 1,
@@ -492,7 +492,7 @@ public partial class RGFxMovieFrontMost : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObj
     /// <summary>
     /// Enum: AnimatedFadeType
     /// </summary>
-    public enum AnimatedFadeType
+    public enum AnimatedFadeType : byte
     {
         AF_Fade_Bats = 0,
         AF_Fade_Riddler = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieGenericError.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieGenericError.g.cs
@@ -172,7 +172,7 @@ public partial class RGFxMovieGenericError : BmSDK.BmGame.RGFxMovie, BmSDK.IGame
     /// <summary>
     /// Enum: GE_Type
     /// </summary>
-    public enum GE_Type
+    public enum GE_Type : byte
     {
         GE_StorageDeviceLost = 0,
         GE_DeviceSelectorRetry = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieHUD.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieHUD.g.cs
@@ -306,7 +306,7 @@ public partial class RGFxMovieHUD : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObject
     /// <summary>
     /// Enum: ObjIcon
     /// </summary>
-    public enum ObjIcon
+    public enum ObjIcon : byte
     {
         OI_Arrow = 0,
         OI_Ticked = 1,
@@ -323,7 +323,7 @@ public partial class RGFxMovieHUD : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObject
     /// <summary>
     /// Enum: JustifyText
     /// </summary>
-    public enum JustifyText
+    public enum JustifyText : byte
     {
         JT_Left = 0,
         JT_Center = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieHudExtendable.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieHudExtendable.g.cs
@@ -809,7 +809,7 @@ public partial class RGFxMovieHudExtendable : BmSDK.BmGame.RGFxMovie, BmSDK.IGam
     /// <summary>
     /// Enum: ObjIcon
     /// </summary>
-    public enum ObjIcon
+    public enum ObjIcon : byte
     {
         OI_Arrow = 0,
         OI_Ticked = 1,
@@ -826,7 +826,7 @@ public partial class RGFxMovieHudExtendable : BmSDK.BmGame.RGFxMovie, BmSDK.IGam
     /// <summary>
     /// Enum: JustifyText
     /// </summary>
-    public enum JustifyText
+    public enum JustifyText : byte
     {
         JT_Left = 0,
         JT_Center = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMoviePopupRequester.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMoviePopupRequester.g.cs
@@ -226,7 +226,7 @@ public partial class RGFxMoviePopupRequester : BmSDK.BmGame.RGFxMovie, BmSDK.IGa
     /// <summary>
     /// Enum: GPopup_Type
     /// </summary>
-    public enum GPopup_Type
+    public enum GPopup_Type : byte
     {
         GPopup_Callback = 0,
         GPopup_AltF4Handler = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieResonatorMinigame.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieResonatorMinigame.g.cs
@@ -779,7 +779,7 @@ public partial class RGFxMovieResonatorMinigame : BmSDK.BmGame.RGFxMovie, BmSDK.
     /// <summary>
     /// Enum: ControllerStatusFields
     /// </summary>
-    public enum ControllerStatusFields
+    public enum ControllerStatusFields : byte
     {
         CSF_UsingController = 0,
         CSF_LeftX_OR_KeyboardX = 1,
@@ -798,7 +798,7 @@ public partial class RGFxMovieResonatorMinigame : BmSDK.BmGame.RGFxMovie, BmSDK.
     /// <summary>
     /// Enum: ResonatorAudioEvent
     /// </summary>
-    public enum ResonatorAudioEvent
+    public enum ResonatorAudioEvent : byte
     {
         RAE_StickStable = 0,
         RAE_BothSticksStable = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieUI.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieUI.g.cs
@@ -1727,7 +1727,7 @@ public partial class RGFxMovieUI : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObject
     /// <summary>
     /// Enum: UIEVENT_ActionType
     /// </summary>
-    public enum UIEVENT_ActionType
+    public enum UIEVENT_ActionType : byte
     {
         UIEVENT_AT_Forward = 0,
         UIEVENT_AT_Back = 1,
@@ -1737,7 +1737,7 @@ public partial class RGFxMovieUI : BmSDK.BmGame.RGFxMovie, BmSDK.IGameObject
     /// <summary>
     /// Enum: UIPromptType
     /// </summary>
-    public enum UIPromptType
+    public enum UIPromptType : byte
     {
         UIPT_None = 0,
         UIPT_MenuA = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieUI_Pause.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieUI_Pause.g.cs
@@ -266,7 +266,7 @@ public partial class RGFxMovieUI_Pause : BmSDK.BmGame.RGFxMovieUI_PauseBase, BmS
     /// <summary>
     /// Enum: PauseMenuItems
     /// </summary>
-    public enum PauseMenuItems
+    public enum PauseMenuItems : byte
     {
         PMI_None = 0,
         PMI_Resume = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieUI_PauseOptionsAudio.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieUI_PauseOptionsAudio.g.cs
@@ -139,7 +139,7 @@ public partial class RGFxMovieUI_PauseOptionsAudio : BmSDK.BmGame.RGFxMovieUI_Pa
     /// <summary>
     /// Enum: AOPMenuItem
     /// </summary>
-    public enum AOPMenuItem
+    public enum AOPMenuItem : byte
     {
         AOPMI_None = 0,
         AOPMI_Subtitles = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieUI_PauseOptionsGame.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieUI_PauseOptionsGame.g.cs
@@ -214,7 +214,7 @@ public partial class RGFxMovieUI_PauseOptionsGame : BmSDK.BmGame.RGFxMovieUI_Pau
     /// <summary>
     /// Enum: GOPMenuItem
     /// </summary>
-    public enum GOPMenuItem
+    public enum GOPMenuItem : byte
     {
         GOPMI_None = 0,
         GOPMI_InvertLook = 1,

--- a/src/BmSDK/Generated/BmGame/RGFxMovieUI_RiddlerMapSelectBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGFxMovieUI_RiddlerMapSelectBase.g.cs
@@ -794,7 +794,7 @@ public partial class RGFxMovieUI_RiddlerMapSelectBase : BmSDK.BmGame.RGFxMovieUI
     /// <summary>
     /// Enum: PopUpTypeMap
     /// </summary>
-    public enum PopUpTypeMap
+    public enum PopUpTypeMap : byte
     {
         PopUpTypeMap_Login = 0,
         PopUpTypeMap_MAX = 1,
@@ -803,7 +803,7 @@ public partial class RGFxMovieUI_RiddlerMapSelectBase : BmSDK.BmGame.RGFxMovieUI
     /// <summary>
     /// Enum: LobbyPageType
     /// </summary>
-    public enum LobbyPageType
+    public enum LobbyPageType : byte
     {
         LobbyPT_Ranked = 0,
         LobbyPT_Campaign = 1,

--- a/src/BmSDK/Generated/BmGame/RGadgetSelectBM2.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGadgetSelectBM2.g.cs
@@ -298,7 +298,7 @@ public partial class RGadgetSelectBM2 : BmSDK.BmGame.RGadgetSelect, BmSDK.IGameO
     /// <summary>
     /// Enum: EGadgetSelectState
     /// </summary>
-    public enum EGadgetSelectState
+    public enum EGadgetSelectState : byte
     {
         GSS_UnInitialised = 0,
         GSS_Closed = 1,

--- a/src/BmSDK/Generated/BmGame/RGadgetSelectV2.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGadgetSelectV2.g.cs
@@ -199,7 +199,7 @@ public partial class RGadgetSelectV2 : BmSDK.BmGame.RGadgetSelect, BmSDK.IGameOb
     /// <summary>
     /// Enum: EGadgetSelectState
     /// </summary>
-    public enum EGadgetSelectState
+    public enum EGadgetSelectState : byte
     {
         GSS_Closed = 0,
         GSS_UpOpen = 1,

--- a/src/BmSDK/Generated/BmGame/RGameInfo.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGameInfo.g.cs
@@ -1923,7 +1923,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EStasisLevel
     /// </summary>
-    public enum EStasisLevel
+    public enum EStasisLevel : byte
     {
         STASISLEVEL_Normal = 0,
         STASISLEVEL_Cheap = 1,
@@ -2203,7 +2203,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: ThugResponseType
     /// </summary>
-    public enum ThugResponseType
+    public enum ThugResponseType : byte
     {
         TRS_None = 0,
         TRS_Ambient = 1,
@@ -2213,7 +2213,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: GameCombatCameraType
     /// </summary>
-    public enum GameCombatCameraType
+    public enum GameCombatCameraType : byte
     {
         GCCT_BrawlComatCamera = 0,
         GCCT_CorridorCombatCamera = 1,
@@ -2240,7 +2240,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: CameraLookAtSpeed
     /// </summary>
-    public enum CameraLookAtSpeed
+    public enum CameraLookAtSpeed : byte
     {
         CLASP_Slow = 0,
         CLASP_Fast = 1,
@@ -2252,7 +2252,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: CameraLookAtStrength
     /// </summary>
-    public enum CameraLookAtStrength
+    public enum CameraLookAtStrength : byte
     {
         CLAS_ForceCamera = 0,
         CLAS_ForceUntilLookAtNeutral = 1,
@@ -2264,7 +2264,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: CameraLookAtType
     /// </summary>
-    public enum CameraLookAtType
+    public enum CameraLookAtType : byte
     {
         CLAT_NoLookAt = 0,
         CLAT_LookAtRotation = 1,
@@ -2276,7 +2276,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECombatLockType
     /// </summary>
-    public enum ECombatLockType
+    public enum ECombatLockType : byte
     {
         ECLT_None = 0,
         ECLT_Thugs = 1,
@@ -2287,7 +2287,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EChallengeModifiers
     /// </summary>
-    public enum EChallengeModifiers
+    public enum EChallengeModifiers : byte
     {
         CMod_None = 0,
         CMod_Neg_ExtremeEnemies = 1,
@@ -2308,7 +2308,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EChallengeModifierType
     /// </summary>
-    public enum EChallengeModifierType
+    public enum EChallengeModifierType : byte
     {
         EChallengeModifier_None = 0,
         EChallengeModifier_Example1 = 1,
@@ -2319,7 +2319,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EChallengeCharacter
     /// </summary>
-    public enum EChallengeCharacter
+    public enum EChallengeCharacter : byte
     {
         ECCID_Batman = 0,
         ECCID_BatmanArmoured = 1,
@@ -2330,7 +2330,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EChallengeMode
     /// </summary>
-    public enum EChallengeMode
+    public enum EChallengeMode : byte
     {
         ECMID_Combat = 0,
         ECMID_CombatEndurance = 1,
@@ -2341,7 +2341,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAchievementID
     /// </summary>
-    public enum EAchievementID
+    public enum EAchievementID : byte
     {
         EACID_None = 0,
         EACID_Im_Batman = 1,
@@ -2420,7 +2420,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: SContexts
     /// </summary>
-    public enum SContexts
+    public enum SContexts : byte
     {
         SContexts_OVERWORLD = 0,
         SContexts_COURT = 1,
@@ -2443,7 +2443,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EContexts
     /// </summary>
-    public enum EContexts
+    public enum EContexts : byte
     {
         EContexts_CHALLENGE = 0,
         EContexts_Nothing = 1,
@@ -2456,7 +2456,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPresenceID
     /// </summary>
-    public enum EPresenceID
+    public enum EPresenceID : byte
     {
         EPresence_Idle = 0,
         EPresence_Frontend = 1,
@@ -2469,7 +2469,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EComboMoveType
     /// </summary>
-    public enum EComboMoveType
+    public enum EComboMoveType : byte
     {
         ECMT_Strike = 0,
         ECMT_PowerStrike = 1,
@@ -2533,7 +2533,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: RagdollStunType
     /// </summary>
-    public enum RagdollStunType
+    public enum RagdollStunType : byte
     {
         RAGSTUN_Generic = 0,
         RAGSTUN_Batarang = 1,
@@ -2569,7 +2569,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGameAction
     /// </summary>
-    public enum EGameAction
+    public enum EGameAction : byte
     {
         GA_None = 0,
         GA_Takedown_CombatTakedown = 1,
@@ -2832,7 +2832,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELive_LiveError
     /// </summary>
-    public enum ELive_LiveError
+    public enum ELive_LiveError : byte
     {
         EL_None = 0,
         EL_LoginLost = 1,
@@ -2856,7 +2856,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGS_Reason
     /// </summary>
-    public enum EGS_Reason
+    public enum EGS_Reason : byte
     {
         EGS_None = 0,
         EGS_StoryExit = 1,
@@ -2869,7 +2869,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGameModes
     /// </summary>
-    public enum EGameModes
+    public enum EGameModes : byte
     {
         EGM_Frontend = 0,
         EGM_Story = 1,
@@ -2880,7 +2880,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELeaderboardColumns
     /// </summary>
-    public enum ELeaderboardColumns
+    public enum ELeaderboardColumns : byte
     {
         ELBC_Medal = 0,
         ELBC_Score = 1,
@@ -2891,7 +2891,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: StreamedCombatWeaponTypes
     /// </summary>
-    public enum StreamedCombatWeaponTypes
+    public enum StreamedCombatWeaponTypes : byte
     {
         COMBATWEAPON_None = 0,
         COMBATWEAPON_Rifle = 1,
@@ -2907,7 +2907,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: StreamedPredWeaponTypes
     /// </summary>
-    public enum StreamedPredWeaponTypes
+    public enum StreamedPredWeaponTypes : byte
     {
         PREDWEAPON_Rifle = 0,
         PREDWEAPON_Shotgun = 1,
@@ -2919,7 +2919,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: VocalPriority
     /// </summary>
-    public enum VocalPriority
+    public enum VocalPriority : byte
     {
         EVP_Default = 0,
         EVP_Low = 1,
@@ -2933,7 +2933,7 @@ public partial class RGameInfo : BmSDK.BmGame.RGameInfoBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: VocalType
     /// </summary>
-    public enum VocalType
+    public enum VocalType : byte
     {
         EVT_Emote = 0,
         EVT_Bark = 1,

--- a/src/BmSDK/Generated/BmGame/RGameRI.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGameRI.g.cs
@@ -1935,7 +1935,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EPhysWalkingType
     /// </summary>
-    public enum EPhysWalkingType
+    public enum EPhysWalkingType : byte
     {
         PHYSWALK_None = 0,
         PHYSWALK_GeoOnly = 1,
@@ -1949,7 +1949,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: WeaponSwitchCallbackResult
     /// </summary>
-    public enum WeaponSwitchCallbackResult
+    public enum WeaponSwitchCallbackResult : byte
     {
         WSCR_None = 0,
         WSCR_Handled = 1,
@@ -1960,7 +1960,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: ETauntNotifyType
     /// </summary>
-    public enum ETauntNotifyType
+    public enum ETauntNotifyType : byte
     {
         TAUNT_HeadAimStart = 0,
         TAUNT_HeadAimStop = 1,
@@ -1971,7 +1971,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EMultiPlayerGameType
     /// </summary>
-    public enum EMultiPlayerGameType
+    public enum EMultiPlayerGameType : byte
     {
         MPGT_SinglePlayer = 0,
         MPGT_NetworkMultiPlayer = 1,
@@ -1983,7 +1983,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EPredAttackState
     /// </summary>
-    public enum EPredAttackState
+    public enum EPredAttackState : byte
     {
         PAS_None = 0,
         PAS_Chase = 1,
@@ -2186,7 +2186,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EChallengeFlow
     /// </summary>
-    public enum EChallengeFlow
+    public enum EChallengeFlow : byte
     {
         ChallengeFlow_NotSet = 0,
         ChallengeFlow_Entry = 1,
@@ -3213,7 +3213,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EGameStatus
     /// </summary>
-    public enum EGameStatus
+    public enum EGameStatus : byte
     {
         GameStatus_None = 0,
         GameStatus_CharacterSelect = 1,
@@ -3231,7 +3231,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EStaticString
     /// </summary>
-    public enum EStaticString
+    public enum EStaticString : byte
     {
         StaticString_Placeholder1 = 0,
         StaticString_Max = 1,
@@ -3240,7 +3240,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EStaticFloat
     /// </summary>
-    public enum EStaticFloat
+    public enum EStaticFloat : byte
     {
         StaticFloat_Placeholder1 = 0,
         StaticFloat_Max = 1,
@@ -3249,7 +3249,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EStaticInt
     /// </summary>
-    public enum EStaticInt
+    public enum EStaticInt : byte
     {
         StaticInt_TMP_MapIndex = 0,
         StaticInt_Max = 1,
@@ -3258,7 +3258,7 @@ public partial class RGameRI : BmSDK.Engine.GameReplicationInfo, BmSDK.IGameObje
     /// <summary>
     /// Enum: EStaticBool
     /// </summary>
-    public enum EStaticBool
+    public enum EStaticBool : byte
     {
         StaticBool_Catwoman_DLC_Checked = 0,
         StaticBool_Max = 1,

--- a/src/BmSDK/Generated/BmGame/RGameplayEventsHydra.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGameplayEventsHydra.g.cs
@@ -334,7 +334,7 @@ public partial class RGameplayEventsHydra : BmSDK.Engine.GameplayEventsWriter, B
     /// <summary>
     /// Enum: EMetricsBestScore
     /// </summary>
-    public enum EMetricsBestScore
+    public enum EMetricsBestScore : byte
     {
         MetBest_LongestGlide = 0,
         MetBest_HighestCombo = 1,
@@ -345,7 +345,7 @@ public partial class RGameplayEventsHydra : BmSDK.Engine.GameplayEventsWriter, B
     /// <summary>
     /// Enum: EMetricsAction
     /// </summary>
-    public enum EMetricsAction
+    public enum EMetricsAction : byte
     {
         MetAct_None = 0,
         MetAct_GroundTravel = 1,

--- a/src/BmSDK/Generated/BmGame/RGrappleGun.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGrappleGun.g.cs
@@ -858,7 +858,7 @@ public partial class RGrappleGun : BmSDK.BmGame.RInventoryGadget, BmSDK.IGameObj
     /// <summary>
     /// Enum: EOffscreenGrappleIconState
     /// </summary>
-    public enum EOffscreenGrappleIconState
+    public enum EOffscreenGrappleIconState : byte
     {
         OGIS_NotDisplayed = 0,
         OGIS_Displayed = 1,
@@ -869,7 +869,7 @@ public partial class RGrappleGun : BmSDK.BmGame.RInventoryGadget, BmSDK.IGameObj
     /// <summary>
     /// Enum: EGrappleFailReason
     /// </summary>
-    public enum EGrappleFailReason
+    public enum EGrappleFailReason : byte
     {
         GFR_Success = 0,
         GFR_CollisionFail = 1,

--- a/src/BmSDK/Generated/BmGame/RGrapplePoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGrapplePoint.g.cs
@@ -234,7 +234,7 @@ public partial class RGrapplePoint : BmSDK.BmGame.RSnapToPositionActor, BmSDK.IG
     /// <summary>
     /// Enum: EGrapplePointOctreeTypeType
     /// </summary>
-    public enum EGrapplePointOctreeTypeType
+    public enum EGrapplePointOctreeTypeType : byte
     {
         GPOT_GrapplePoint = 0,
         GPOT_VantagePoint = 1,
@@ -244,7 +244,7 @@ public partial class RGrapplePoint : BmSDK.BmGame.RSnapToPositionActor, BmSDK.IG
     /// <summary>
     /// Enum: ELocalGrapplePlayer
     /// </summary>
-    public enum ELocalGrapplePlayer
+    public enum ELocalGrapplePlayer : byte
     {
         LGP_Player1 = 0,
         LGP_Player2 = 1,
@@ -647,7 +647,7 @@ public partial class RGrapplePoint : BmSDK.BmGame.RSnapToPositionActor, BmSDK.IG
     /// <summary>
     /// Enum: GrapplePointTypes
     /// </summary>
-    public enum GrapplePointTypes
+    public enum GrapplePointTypes : byte
     {
         GPT_Edge = 0,
         GPT_WallEdge = 1,

--- a/src/BmSDK/Generated/BmGame/RGuardPoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RGuardPoint.g.cs
@@ -150,7 +150,7 @@ public partial class RGuardPoint : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: GuardLocationType
     /// </summary>
-    public enum GuardLocationType
+    public enum GuardLocationType : byte
     {
         GLC_Generic = 0,
         GLC_Door = 1,

--- a/src/BmSDK/Generated/BmGame/RHUD.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHUD.g.cs
@@ -342,7 +342,7 @@ public partial class RHUD : BmSDK.BmGame.RHUDBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECinematicPriorities
     /// </summary>
-    public enum ECinematicPriorities
+    public enum ECinematicPriorities : byte
     {
         CP_Front = 0,
         CP_Middle = 1,

--- a/src/BmSDK/Generated/BmGame/RHUDPrompt.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHUDPrompt.g.cs
@@ -390,7 +390,7 @@ public partial class RHUDPrompt : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EControlIcon
     /// </summary>
-    public enum EControlIcon
+    public enum EControlIcon : byte
     {
         CI_None = 0,
         CI_UI_Start = 1,

--- a/src/BmSDK/Generated/BmGame/RHarpoonDragBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHarpoonDragBase.g.cs
@@ -76,7 +76,7 @@ public partial class RHarpoonDragBase : BmSDK.Engine.InterpActor, BmSDK.IGameObj
     /// <summary>
     /// Enum: DragMovingState
     /// </summary>
-    public enum DragMovingState
+    public enum DragMovingState : byte
     {
         DMS_Moving = 0,
         DMS_AtStart = 1,

--- a/src/BmSDK/Generated/BmGame/RHarpoonGun.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHarpoonGun.g.cs
@@ -503,7 +503,7 @@ public partial class RHarpoonGun : BmSDK.BmGame.RInventoryGadget, BmSDK.IGameObj
     /// <summary>
     /// Enum: EBatclawFireDirections
     /// </summary>
-    public enum EBatclawFireDirections
+    public enum EBatclawFireDirections : byte
     {
         EBFD_Forward = 0,
         EBFD_Left = 1,
@@ -515,7 +515,7 @@ public partial class RHarpoonGun : BmSDK.BmGame.RInventoryGadget, BmSDK.IGameObj
     /// <summary>
     /// Enum: HarpoonAttackType
     /// </summary>
-    public enum HarpoonAttackType
+    public enum HarpoonAttackType : byte
     {
         HAT_Legs = 0,
         HAT_Torso = 1,

--- a/src/BmSDK/Generated/BmGame/RHidePoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHidePoint.g.cs
@@ -715,7 +715,7 @@ public partial class RHidePoint : BmSDK.Engine.FracturedStaticMeshActor, BmSDK.B
     /// <summary>
     /// Enum: EVantageWallInfo
     /// </summary>
-    public enum EVantageWallInfo
+    public enum EVantageWallInfo : byte
     {
         VWI_Default = 0,
         VWI_TwoWallCorner = 1,

--- a/src/BmSDK/Generated/BmGame/RHudExtensionGeneral.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHudExtensionGeneral.g.cs
@@ -260,7 +260,7 @@ public partial class RHudExtensionGeneral : BmSDK.BmGame.RHudExtension, BmSDK.IG
     /// <summary>
     /// Enum: ObjIcon
     /// </summary>
-    public enum ObjIcon
+    public enum ObjIcon : byte
     {
         OI_Arrow = 0,
         OI_Ticked = 1,
@@ -277,7 +277,7 @@ public partial class RHudExtensionGeneral : BmSDK.BmGame.RHudExtension, BmSDK.IG
     /// <summary>
     /// Enum: JustifyText
     /// </summary>
-    public enum JustifyText
+    public enum JustifyText : byte
     {
         JT_Left = 0,
         JT_Center = 1,

--- a/src/BmSDK/Generated/BmGame/RHudExtensionInvestigate.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHudExtensionInvestigate.g.cs
@@ -590,7 +590,7 @@ public partial class RHudExtensionInvestigate : BmSDK.BmGame.RHudExtension, BmSD
     /// <summary>
     /// Enum: EvidenceDisplayType
     /// </summary>
-    public enum EvidenceDisplayType
+    public enum EvidenceDisplayType : byte
     {
         EEDT_None = 0,
         EEDT_NPC = 1,
@@ -602,7 +602,7 @@ public partial class RHudExtensionInvestigate : BmSDK.BmGame.RHudExtension, BmSD
     /// <summary>
     /// Enum: ENPCType
     /// </summary>
-    public enum ENPCType
+    public enum ENPCType : byte
     {
         ENPCType_None = 0,
         ENPCType_Thug = 1,
@@ -628,7 +628,7 @@ public partial class RHudExtensionInvestigate : BmSDK.BmGame.RHudExtension, BmSD
     /// <summary>
     /// Enum: EHeartBeatType
     /// </summary>
-    public enum EHeartBeatType
+    public enum EHeartBeatType : byte
     {
         EHeartBeatType_Fine = 0,
         EHeartBeatType_Nervous = 1,
@@ -654,7 +654,7 @@ public partial class RHudExtensionInvestigate : BmSDK.BmGame.RHudExtension, BmSD
     /// <summary>
     /// Enum: ScannerPrompt
     /// </summary>
-    public enum ScannerPrompt
+    public enum ScannerPrompt : byte
     {
         ScannerPrompt_None = 0,
         ScannerPrompt_PressAndHoldToScan = 1,

--- a/src/BmSDK/Generated/BmGame/RHudExtensionTargets.g.cs
+++ b/src/BmSDK/Generated/BmGame/RHudExtensionTargets.g.cs
@@ -421,7 +421,7 @@ public partial class RHudExtensionTargets : BmSDK.BmGame.RHudExtension, BmSDK.IG
     /// <summary>
     /// Enum: EObjectiveMarkerTypes
     /// </summary>
-    public enum EObjectiveMarkerTypes
+    public enum EObjectiveMarkerTypes : byte
     {
         OMT_Objective = 0,
         OMT_Custom = 1,

--- a/src/BmSDK/Generated/BmGame/RInventoryGadget.g.cs
+++ b/src/BmSDK/Generated/BmGame/RInventoryGadget.g.cs
@@ -954,7 +954,7 @@ public partial class RInventoryGadget : BmSDK.Engine.Inventory, BmSDK.BmGame.RXr
     /// <summary>
     /// Enum: FGadgetIDs
     /// </summary>
-    public enum FGadgetIDs
+    public enum FGadgetIDs : byte
     {
         FGID_None = 0,
         FGID_Batarang = 1,
@@ -1897,7 +1897,7 @@ public partial class RInventoryGadget : BmSDK.Engine.Inventory, BmSDK.BmGame.RXr
     /// <summary>
     /// Enum: CoverCornerType
     /// </summary>
-    public enum CoverCornerType
+    public enum CoverCornerType : byte
     {
         CCT_NoCorner = 0,
         CCT_LeftCorner = 1,
@@ -1908,7 +1908,7 @@ public partial class RInventoryGadget : BmSDK.Engine.Inventory, BmSDK.BmGame.RXr
     /// <summary>
     /// Enum: BatarangThrowType
     /// </summary>
-    public enum BatarangThrowType
+    public enum BatarangThrowType : byte
     {
         BTT_NullThrow = 0,
         BTT_StandingThrow = 1,
@@ -1927,7 +1927,7 @@ public partial class RInventoryGadget : BmSDK.Engine.Inventory, BmSDK.BmGame.RXr
     /// <summary>
     /// Enum: PlayerWantsToCrouch
     /// </summary>
-    public enum PlayerWantsToCrouch
+    public enum PlayerWantsToCrouch : byte
     {
         PWC_Crouch = 0,
         PWC_StandUp = 1,
@@ -1937,7 +1937,7 @@ public partial class RInventoryGadget : BmSDK.Engine.Inventory, BmSDK.BmGame.RXr
     /// <summary>
     /// Enum: GadgetEquipState
     /// </summary>
-    public enum GadgetEquipState
+    public enum GadgetEquipState : byte
     {
         GS_AttachedToBelt = 0,
         GS_AttachetToHand = 1,

--- a/src/BmSDK/Generated/BmGame/RInventoryManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RInventoryManager.g.cs
@@ -251,7 +251,7 @@ public partial class RInventoryManager : BmSDK.Engine.InventoryManager, BmSDK.IG
     /// <summary>
     /// Enum: GadgetSelectionDirection
     /// </summary>
-    public enum GadgetSelectionDirection
+    public enum GadgetSelectionDirection : byte
     {
         GSD_Up = 0,
         GSD_Down = 1,

--- a/src/BmSDK/Generated/BmGame/RJokerTannoy.g.cs
+++ b/src/BmSDK/Generated/BmGame/RJokerTannoy.g.cs
@@ -382,7 +382,7 @@ public partial class RJokerTannoy : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETannoyChar
     /// </summary>
-    public enum ETannoyChar
+    public enum ETannoyChar : byte
     {
         TANCHAR_Harley = 0,
         TANCHAR_Joker = 1,

--- a/src/BmSDK/Generated/BmGame/RLevelTransition.g.cs
+++ b/src/BmSDK/Generated/BmGame/RLevelTransition.g.cs
@@ -635,7 +635,7 @@ public partial class RLevelTransition : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMapIconType
     /// </summary>
-    public enum EMapIconType
+    public enum EMapIconType : byte
     {
         MapIcon_None = 0,
         MapIcon_DoorSmall = 1,

--- a/src/BmSDK/Generated/BmGame/RLevelTransitionDoorBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RLevelTransitionDoorBase.g.cs
@@ -657,7 +657,7 @@ public partial class RLevelTransitionDoorBase : BmSDK.BmGame.RLevelTransitionP, 
     /// <summary>
     /// Enum: ECombatLockSides
     /// </summary>
-    public enum ECombatLockSides
+    public enum ECombatLockSides : byte
     {
         CombatLock_BothSides = 0,
         CombatLock_RedDirectionOnly = 1,

--- a/src/BmSDK/Generated/BmGame/RMagneticBlast.g.cs
+++ b/src/BmSDK/Generated/BmGame/RMagneticBlast.g.cs
@@ -580,7 +580,7 @@ public partial class RMagneticBlast : BmSDK.BmGame.RInventoryGadget, BmSDK.IGame
     /// <summary>
     /// Enum: MBImpulseType
     /// </summary>
-    public enum MBImpulseType
+    public enum MBImpulseType : byte
     {
         MBI_KeepLast = 0,
         MBI_Repel = 1,
@@ -591,7 +591,7 @@ public partial class RMagneticBlast : BmSDK.BmGame.RInventoryGadget, BmSDK.IGame
     /// <summary>
     /// Enum: MBControlType
     /// </summary>
-    public enum MBControlType
+    public enum MBControlType : byte
     {
         MB_NewControls = 0,
         MB_RubbishOldControls = 1,

--- a/src/BmSDK/Generated/BmGame/RMagneticMatineeObject.g.cs
+++ b/src/BmSDK/Generated/BmGame/RMagneticMatineeObject.g.cs
@@ -334,7 +334,7 @@ public partial class RMagneticMatineeObject : BmSDK.Engine.InterpActor, BmSDK.Bm
     /// <summary>
     /// Enum: EMatineeMoveState
     /// </summary>
-    public enum EMatineeMoveState
+    public enum EMatineeMoveState : byte
     {
         MMS_NotMoving = 0,
         MMS_MovedByMotor = 1,
@@ -422,7 +422,7 @@ public partial class RMagneticMatineeObject : BmSDK.Engine.InterpActor, BmSDK.Bm
     /// <summary>
     /// Enum: MagMatObjEmitType
     /// </summary>
-    public enum MagMatObjEmitType
+    public enum MagMatObjEmitType : byte
     {
         MMOET_ForwardsOnly = 0,
         MMOET_BackwardsOnly = 1,

--- a/src/BmSDK/Generated/BmGame/RMagneticSurfaceSMBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RMagneticSurfaceSMBase.g.cs
@@ -592,7 +592,7 @@ public partial class RMagneticSurfaceSMBase : BmSDK.Engine.Actor, BmSDK.BmGame.R
     /// <summary>
     /// Enum: EEmergencyStopMode
     /// </summary>
-    public enum EEmergencyStopMode
+    public enum EEmergencyStopMode : byte
     {
         EESM_AlwaysStop = 0,
         EESM_StopWhenMatineePlaysForward = 1,
@@ -603,7 +603,7 @@ public partial class RMagneticSurfaceSMBase : BmSDK.Engine.Actor, BmSDK.BmGame.R
     /// <summary>
     /// Enum: EForceFieldAxis
     /// </summary>
-    public enum EForceFieldAxis
+    public enum EForceFieldAxis : byte
     {
         EFFA_None = 0,
         EFFA_X_Axis = 1,

--- a/src/BmSDK/Generated/BmGame/RMapPlacementMarker.g.cs
+++ b/src/BmSDK/Generated/BmGame/RMapPlacementMarker.g.cs
@@ -117,7 +117,7 @@ public partial class RMapPlacementMarker : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: MapMarkerType
     /// </summary>
-    public enum MapMarkerType
+    public enum MapMarkerType : byte
     {
         MMT_Objective = 0,
         MMT_CrimeScene = 1,

--- a/src/BmSDK/Generated/BmGame/RNavMeshCollisionSettingsVolume.g.cs
+++ b/src/BmSDK/Generated/BmGame/RNavMeshCollisionSettingsVolume.g.cs
@@ -81,7 +81,7 @@ public partial class RNavMeshCollisionSettingsVolume : BmSDK.Engine.Volume, BmSD
     /// <summary>
     /// Enum: ENavMeshCollisionSettings
     /// </summary>
-    public enum ENavMeshCollisionSettings
+    public enum ENavMeshCollisionSettings : byte
     {
         ENavColl_None = 0,
         ENavColl_BlockAllRagdolls = 1,

--- a/src/BmSDK/Generated/BmGame/RNavigationActor.g.cs
+++ b/src/BmSDK/Generated/BmGame/RNavigationActor.g.cs
@@ -171,7 +171,7 @@ public partial class RNavigationActor : BmSDK.Engine.Actor, BmSDK.Engine.Interfa
     /// <summary>
     /// Enum: NavActorState
     /// </summary>
-    public enum NavActorState
+    public enum NavActorState : byte
     {
         ENAS_None = 0,
         ENAS_Waiting = 1,

--- a/src/BmSDK/Generated/BmGame/RNavigationHandle.g.cs
+++ b/src/BmSDK/Generated/BmGame/RNavigationHandle.g.cs
@@ -1556,7 +1556,7 @@ public partial class RNavigationHandle : BmSDK.Engine.NavigationHandle, BmSDK.IG
     /// <summary>
     /// Enum: PathStatus
     /// </summary>
-    public enum PathStatus
+    public enum PathStatus : byte
     {
         PATH_None = 0,
         PATH_Waiting = 1,

--- a/src/BmSDK/Generated/BmGame/RPawn.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawn.g.cs
@@ -954,7 +954,7 @@ public partial class RPawn : BmSDK.Engine.Pawn, BmSDK.IGameObject
     /// <summary>
     /// Enum: PawnHistoryType
     /// </summary>
-    public enum PawnHistoryType
+    public enum PawnHistoryType : byte
     {
         PHT_General = 0,
         PHT_Behaviour = 1,
@@ -991,7 +991,7 @@ public partial class RPawn : BmSDK.Engine.Pawn, BmSDK.IGameObject
     /// <summary>
     /// Enum: StunnedHitType
     /// </summary>
-    public enum StunnedHitType
+    public enum StunnedHitType : byte
     {
         HT_None = 0,
         HT_Head = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnBossGrundyBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnBossGrundyBase.g.cs
@@ -4506,7 +4506,7 @@ public partial class RPawnBossGrundyBase : BmSDK.BmGame.RPawnVillain, BmSDK.BmGa
     /// <summary>
     /// Enum: EGrundyForcedAttack
     /// </summary>
-    public enum EGrundyForcedAttack
+    public enum EGrundyForcedAttack : byte
     {
         EGrundyForcedAttack_Swing = 0,
         EGrundyForcedAttack_Smash = 1,
@@ -4520,7 +4520,7 @@ public partial class RPawnBossGrundyBase : BmSDK.BmGame.RPawnVillain, BmSDK.BmGa
     /// <summary>
     /// Enum: EGrundyAttacks
     /// </summary>
-    public enum EGrundyAttacks
+    public enum EGrundyAttacks : byte
     {
         GRUNDYATTACK_Maggots = 0,
         GRUNDYATTACK_Smash = 1,
@@ -4532,7 +4532,7 @@ public partial class RPawnBossGrundyBase : BmSDK.BmGame.RPawnVillain, BmSDK.BmGa
     /// <summary>
     /// Enum: EGrundyToggleType
     /// </summary>
-    public enum EGrundyToggleType
+    public enum EGrundyToggleType : byte
     {
         GRUNDYTOGGLE_Leave = 0,
         GRUNDYTOGGLE_Enable = 1,
@@ -4544,7 +4544,7 @@ public partial class RPawnBossGrundyBase : BmSDK.BmGame.RPawnVillain, BmSDK.BmGa
     /// <summary>
     /// Enum: EGrundyWeightSide
     /// </summary>
-    public enum EGrundyWeightSide
+    public enum EGrundyWeightSide : byte
     {
         GRUNDYWEIGHTSIDE_Left = 0,
         GRUNDYWEIGHTSIDE_Right = 1,
@@ -4556,7 +4556,7 @@ public partial class RPawnBossGrundyBase : BmSDK.BmGame.RPawnVillain, BmSDK.BmGa
     /// <summary>
     /// Enum: SolomonGrundyState
     /// </summary>
-    public enum SolomonGrundyState
+    public enum SolomonGrundyState : byte
     {
         SGS_Normal = 0,
         SGS_OnFire = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnBossRasBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnBossRasBase.g.cs
@@ -847,7 +847,7 @@ public partial class RPawnBossRasBase : BmSDK.BmGame.RPawnVillainNinjaBase, BmSD
     /// <summary>
     /// Enum: EBatmanMovement
     /// </summary>
-    public enum EBatmanMovement
+    public enum EBatmanMovement : byte
     {
         EBM_None = 0,
         EBM_Clockwise = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnCharacter.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnCharacter.g.cs
@@ -2981,7 +2981,7 @@ public partial class RPawnCharacter : BmSDK.BmGame.RPawn, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERagdollVsNavMesh
     /// </summary>
-    public enum ERagdollVsNavMesh
+    public enum ERagdollVsNavMesh : byte
     {
         RAGvsNAV_Constrain = 0,
         RAGvsNAV_ConstrainWhenNotDead = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnCombat.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnCombat.g.cs
@@ -1997,7 +1997,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: SimultaneousCounterAnimType
     /// </summary>
-    public enum SimultaneousCounterAnimType
+    public enum SimultaneousCounterAnimType : byte
     {
         SCAT_None = 0,
         SCAT_2ThugAngled = 1,
@@ -2011,7 +2011,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: SimultaneousCounterFormation
     /// </summary>
-    public enum SimultaneousCounterFormation
+    public enum SimultaneousCounterFormation : byte
     {
         SCF_None = 0,
         SCF_FrontRight = 1,
@@ -2032,7 +2032,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: AdditionalRagdollForce
     /// </summary>
-    public enum AdditionalRagdollForce
+    public enum AdditionalRagdollForce : byte
     {
         ARF_None = 0,
         ARF_SpinLeft = 1,
@@ -2044,7 +2044,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: TargetStrikeResponse
     /// </summary>
-    public enum TargetStrikeResponse
+    public enum TargetStrikeResponse : byte
     {
         TSR_None = 0,
         TSR_Block = 1,
@@ -2056,7 +2056,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: DamageResult
     /// </summary>
-    public enum DamageResult
+    public enum DamageResult : byte
     {
         DMG_None = 0,
         DMG_Hit = 1,
@@ -2069,7 +2069,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: CounterLimb
     /// </summary>
-    public enum CounterLimb
+    public enum CounterLimb : byte
     {
         ECL_None = 0,
         ECL_LeftArm = 1,
@@ -2095,7 +2095,7 @@ public partial class RPawnCombat : BmSDK.BmGame.RPawnCharacter, BmSDK.IGameObjec
     /// <summary>
     /// Enum: ECombatPawnType
     /// </summary>
-    public enum ECombatPawnType
+    public enum ECombatPawnType : byte
     {
         ECPT_None = 0,
         ECPT_Player = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnPlayer.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnPlayer.g.cs
@@ -3926,7 +3926,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EQuickGadgetType
     /// </summary>
-    public enum EQuickGadgetType
+    public enum EQuickGadgetType : byte
     {
         QGT_GadgetLT = 0,
         QGT_GadgetRT = 1,
@@ -4100,7 +4100,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: PerchDirection
     /// </summary>
-    public enum PerchDirection
+    public enum PerchDirection : byte
     {
         PD_Forward = 0,
         PD_Backward = 1,
@@ -4110,7 +4110,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: OverheadRopeControlPointType
     /// </summary>
-    public enum OverheadRopeControlPointType
+    public enum OverheadRopeControlPointType : byte
     {
         ORCT_LeftHand = 0,
         ORCT_RightHand = 1,
@@ -4148,7 +4148,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EStealthTakeDownStages
     /// </summary>
-    public enum EStealthTakeDownStages
+    public enum EStealthTakeDownStages : byte
     {
         ESTDS_CornerGrab = 0,
         ESTDS_FallingTakeDown = 1,
@@ -4191,7 +4191,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EBatmanPoseType
     /// </summary>
-    public enum EBatmanPoseType
+    public enum EBatmanPoseType : byte
     {
         EBPT_Standard = 0,
         EBPT_Combat = 1,
@@ -4377,7 +4377,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EArmourType
     /// </summary>
-    public enum EArmourType
+    public enum EArmourType : byte
     {
         EA_ArmourMelee = 0,
         EA_ArmourBallistic = 1,
@@ -4593,7 +4593,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EPlayerLandMoves
     /// </summary>
-    public enum EPlayerLandMoves
+    public enum EPlayerLandMoves : byte
     {
         PLM_StraightLand = 0,
         PLM_JumpLandToRun = 1,
@@ -4608,7 +4608,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EBatmanGadgetList
     /// </summary>
-    public enum EBatmanGadgetList
+    public enum EBatmanGadgetList : byte
     {
         BGL_Batarang = 0,
         BGL_RCBatarang = 1,
@@ -4630,7 +4630,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EnvironmentAnimationDirection
     /// </summary>
-    public enum EnvironmentAnimationDirection
+    public enum EnvironmentAnimationDirection : byte
     {
         EAD_DoesntMatter = 0,
         EAD_Left = 1,
@@ -4641,7 +4641,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EnvironmentFeelerState
     /// </summary>
-    public enum EnvironmentFeelerState
+    public enum EnvironmentFeelerState : byte
     {
         EFS_Walking = 0,
         EFS_InCover = 1,
@@ -5078,7 +5078,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EHangLedgeType
     /// </summary>
-    public enum EHangLedgeType
+    public enum EHangLedgeType : byte
     {
         HLT_Braced = 0,
         HLT_Dangle = 1,
@@ -5089,7 +5089,7 @@ public partial class RPawnPlayer : BmSDK.BmGame.RPawnPlayerCombat, BmSDK.BmGame.
     /// <summary>
     /// Enum: EnvironmentSpecialMoveTypes
     /// </summary>
-    public enum EnvironmentSpecialMoveTypes
+    public enum EnvironmentSpecialMoveTypes : byte
     {
         ESMT_None = 0,
         ESMT_LowBarrier = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnPlayerAnim.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnPlayerAnim.g.cs
@@ -312,7 +312,7 @@ public partial class RPawnPlayerAnim : BmSDK.BmGame.RPawnCombat, BmSDK.IGameObje
     /// <summary>
     /// Enum: AimingConfigDesc
     /// </summary>
-    public enum AimingConfigDesc
+    public enum AimingConfigDesc : byte
     {
         ACD_StandardAimingConfig = 0,
         ACD_HarpoonAimingConfig = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnPlayerCatwomanBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnPlayerCatwomanBase.g.cs
@@ -514,7 +514,7 @@ public partial class RPawnPlayerCatwomanBase : BmSDK.BmGame.RPawnPlayer, BmSDK.I
     /// <summary>
     /// Enum: ESwingDirection
     /// </summary>
-    public enum ESwingDirection
+    public enum ESwingDirection : byte
     {
         SWD_Default = 0,
         SWD_Left = 1,
@@ -527,7 +527,7 @@ public partial class RPawnPlayerCatwomanBase : BmSDK.BmGame.RPawnPlayer, BmSDK.I
     /// <summary>
     /// Enum: EAutoSwingState
     /// </summary>
-    public enum EAutoSwingState
+    public enum EAutoSwingState : byte
     {
         ASS_None = 0,
         ASS_InitialJump = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnPlayerCombat.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnPlayerCombat.g.cs
@@ -2258,7 +2258,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: EWeaponDestroyType
     /// </summary>
-    public enum EWeaponDestroyType
+    public enum EWeaponDestroyType : byte
     {
         WDL_Unarmed = 0,
         WDT_Bat = 1,
@@ -2434,7 +2434,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: ETakedownMovement
     /// </summary>
-    public enum ETakedownMovement
+    public enum ETakedownMovement : byte
     {
         TDM_None = 0,
         TDM_Forwards = 1,
@@ -2445,7 +2445,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: ETakedownType
     /// </summary>
-    public enum ETakedownType
+    public enum ETakedownType : byte
     {
         TDT_Unarmed = 0,
         TDT_Pipe = 1,
@@ -2460,7 +2460,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: ETakedownSpeed
     /// </summary>
-    public enum ETakedownSpeed
+    public enum ETakedownSpeed : byte
     {
         TS_Slow = 0,
         TS_Fast = 1,
@@ -2790,7 +2790,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: CounterStrength
     /// </summary>
-    public enum CounterStrength
+    public enum CounterStrength : byte
     {
         ECS_Weak = 0,
         ECS_Strong = 1,
@@ -2800,7 +2800,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: CounterEnvironmentDir
     /// </summary>
-    public enum CounterEnvironmentDir
+    public enum CounterEnvironmentDir : byte
     {
         ECED_None = 0,
         ECED_Front = 1,
@@ -2813,7 +2813,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: CounterMoveDir
     /// </summary>
-    public enum CounterMoveDir
+    public enum CounterMoveDir : byte
     {
         ECD_Front = 0,
         ECD_Back = 1,
@@ -3269,7 +3269,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeTargetType
     /// </summary>
-    public enum StrikeTargetType
+    public enum StrikeTargetType : byte
     {
         STT_Unarmed = 0,
         STT_Pipe = 1,
@@ -3285,7 +3285,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeTurnMotion
     /// </summary>
-    public enum StrikeTurnMotion
+    public enum StrikeTurnMotion : byte
     {
         STM_None = 0,
         STM_Clockwise = 1,
@@ -3296,7 +3296,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeDamageDirection
     /// </summary>
-    public enum StrikeDamageDirection
+    public enum StrikeDamageDirection : byte
     {
         SDD_None = 0,
         SDD_HorizontalAcrossBody = 1,
@@ -3309,7 +3309,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: CameraDirection
     /// </summary>
-    public enum CameraDirection
+    public enum CameraDirection : byte
     {
         CAM_None = 0,
         CAM_Left = 1,
@@ -3320,7 +3320,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeRange
     /// </summary>
-    public enum StrikeRange
+    public enum StrikeRange : byte
     {
         SR_None = 0,
         SR_Close = 1,
@@ -3332,7 +3332,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeStrength
     /// </summary>
-    public enum StrikeStrength
+    public enum StrikeStrength : byte
     {
         SS_None = 0,
         SS_Weak = 1,
@@ -3352,7 +3352,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeHand
     /// </summary>
-    public enum StrikeHand
+    public enum StrikeHand : byte
     {
         SH_None = 0,
         SH_Left = 1,
@@ -3363,7 +3363,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: StrikeDirection
     /// </summary>
-    public enum StrikeDirection
+    public enum StrikeDirection : byte
     {
         SD_None = 0,
         SD_Front = 1,
@@ -3376,7 +3376,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: HitStrength
     /// </summary>
-    public enum HitStrength
+    public enum HitStrength : byte
     {
         HIT_Strong = 0,
         HIT_Weak = 1,
@@ -3388,7 +3388,7 @@ public partial class RPawnPlayerCombat : BmSDK.BmGame.RPawnPlayerAnim, BmSDK.IGa
     /// <summary>
     /// Enum: BoneNameList
     /// </summary>
-    public enum BoneNameList
+    public enum BoneNameList : byte
     {
         BONE_None = 0,
         BONE_Head = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnVillain.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnVillain.g.cs
@@ -3788,7 +3788,7 @@ public partial class RPawnVillain : BmSDK.BmGame.RBMPawnAI, BmSDK.BmGame.RSpotab
     /// <summary>
     /// Enum: CombatReadinessState
     /// </summary>
-    public enum CombatReadinessState
+    public enum CombatReadinessState : byte
     {
         CRS_None = 0,
         CRS_LoadingAnims = 1,
@@ -3904,7 +3904,7 @@ public partial class RPawnVillain : BmSDK.BmGame.RBMPawnAI, BmSDK.BmGame.RSpotab
     /// <summary>
     /// Enum: EArrayPropertyType
     /// </summary>
-    public enum EArrayPropertyType
+    public enum EArrayPropertyType : byte
     {
         EAPT_None = 0,
         EAPT_ClearAndAdd = 1,
@@ -3940,7 +3940,7 @@ public partial class RPawnVillain : BmSDK.BmGame.RBMPawnAI, BmSDK.BmGame.RSpotab
     /// <summary>
     /// Enum: AttackCounterTypes
     /// </summary>
-    public enum AttackCounterTypes
+    public enum AttackCounterTypes : byte
     {
         ACT_Counter = 0,
         ACT_Evade = 1,
@@ -3952,7 +3952,7 @@ public partial class RPawnVillain : BmSDK.BmGame.RBMPawnAI, BmSDK.BmGame.RSpotab
     /// <summary>
     /// Enum: StuckRagdollSolutionType
     /// </summary>
-    public enum StuckRagdollSolutionType
+    public enum StuckRagdollSolutionType : byte
     {
         SRST_LeaveStuck = 0,
         SRST_Freeze = 1,

--- a/src/BmSDK/Generated/BmGame/RPawnVillainGunBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPawnVillainGunBase.g.cs
@@ -394,7 +394,7 @@ public partial class RPawnVillainGunBase : BmSDK.BmGame.RPawnVillain, BmSDK.IGam
     /// <summary>
     /// Enum: LeftRight
     /// </summary>
-    public enum LeftRight
+    public enum LeftRight : byte
     {
         LR_Left = 0,
         LR_Right = 1,
@@ -404,7 +404,7 @@ public partial class RPawnVillainGunBase : BmSDK.BmGame.RPawnVillain, BmSDK.IGam
     /// <summary>
     /// Enum: ThermalGoggleState
     /// </summary>
-    public enum ThermalGoggleState
+    public enum ThermalGoggleState : byte
     {
         TGS_Off = 0,
         TGS_Active = 1,

--- a/src/BmSDK/Generated/BmGame/RPersistentData.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPersistentData.g.cs
@@ -1071,7 +1071,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETutorialType
     /// </summary>
-    public enum ETutorialType
+    public enum ETutorialType : byte
     {
         TUT_None = 0,
         TUT_Combat_Strike = 1,
@@ -3155,7 +3155,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBatmanChallenge
     /// </summary>
-    public enum EBatmanChallenge
+    public enum EBatmanChallenge : byte
     {
         EBatChal_None = 0,
         EBatChal = 1,
@@ -3209,7 +3209,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERiddlerLocationName
     /// </summary>
-    public enum ERiddlerLocationName
+    public enum ERiddlerLocationName : byte
     {
         RiddlerLoc_OWA = 0,
         RiddlerLoc_OWB = 1,
@@ -3226,7 +3226,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPMapNames
     /// </summary>
-    public enum EPMapNames
+    public enum EPMapNames : byte
     {
         PMAP_None = 0,
         PMAP_Overworld = 1,
@@ -3242,7 +3242,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECharacterViewer
     /// </summary>
-    public enum ECharacterViewer
+    public enum ECharacterViewer : byte
     {
         EViewer_None = 0,
         EViewer_Batman = 1,
@@ -3323,7 +3323,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EProgressLocations
     /// </summary>
-    public enum EProgressLocations
+    public enum EProgressLocations : byte
     {
         EPL_Unknown = 0,
         EPL_GCPD = 1,
@@ -3352,7 +3352,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECustomWayPointType
     /// </summary>
-    public enum ECustomWayPointType
+    public enum ECustomWayPointType : byte
     {
         CustomWayType_Proximity = 0,
         CustomWayType_MapObj = 1,
@@ -3364,7 +3364,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EProgressCharacter
     /// </summary>
-    public enum EProgressCharacter
+    public enum EProgressCharacter : byte
     {
         ProgressCharacter_Azrael = 0,
         ProgressCharacter_Bane = 1,
@@ -3384,7 +3384,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EConceptArt
     /// </summary>
-    public enum EConceptArt
+    public enum EConceptArt : byte
     {
         ConceptArt_None = 0,
         ConceptArt_Renders_Catwoman = 1,
@@ -3473,7 +3473,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBioCharacter
     /// </summary>
-    public enum EBioCharacter
+    public enum EBioCharacter : byte
     {
         BioCharacter_Batman = 0,
         BioCharacter_Bruce_Wayne = 1,
@@ -3513,7 +3513,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETapeCharacter
     /// </summary>
-    public enum ETapeCharacter
+    public enum ETapeCharacter : byte
     {
         Tape_None = 0,
         Tape_Catwoman = 1,
@@ -3532,7 +3532,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECM_MedalType
     /// </summary>
-    public enum ECM_MedalType
+    public enum ECM_MedalType : byte
     {
         ECM_Medal_None = 0,
         ECM_Medal_Bronze = 1,
@@ -3544,7 +3544,7 @@ public partial class RPersistentData : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: PDVersion
     /// </summary>
-    public enum PDVersion
+    public enum PDVersion : byte
     {
         PDVer_Initial = 0,
         PDVer_XPLevel = 1,

--- a/src/BmSDK/Generated/BmGame/RPersistentOptions.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPersistentOptions.g.cs
@@ -1685,7 +1685,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPlayerOptions
     /// </summary>
-    public enum EPlayerOptions
+    public enum EPlayerOptions : byte
     {
         EPlayerOption_InvertMouse = 0,
         EPlayerOption_InvertRotation = 1,
@@ -1702,7 +1702,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGeneralOptions
     /// </summary>
-    public enum EGeneralOptions
+    public enum EGeneralOptions : byte
     {
         ECommonOption_Difficulty = 0,
         ECommonOption_PCControlsPage = 1,
@@ -1722,7 +1722,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERandomSwitchStateType
     /// </summary>
-    public enum ERandomSwitchStateType
+    public enum ERandomSwitchStateType : byte
     {
         ERSS_None = 0,
         ERSS_DeathBane = 1,
@@ -1749,7 +1749,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: HelpTextLevel
     /// </summary>
-    public enum HelpTextLevel
+    public enum HelpTextLevel : byte
     {
         HelpText_None = 0,
         HelpText_Some = 1,
@@ -1760,7 +1760,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: DifficultyLevels
     /// </summary>
-    public enum DifficultyLevels
+    public enum DifficultyLevels : byte
     {
         Difficulty_Easy = 0,
         Difficulty_Normal = 1,
@@ -1771,7 +1771,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ChallengeMode
     /// </summary>
-    public enum ChallengeMode
+    public enum ChallengeMode : byte
     {
         ChallengeMode_Ranked = 0,
         ChallengeMode_Campaign = 1,
@@ -1782,7 +1782,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: DDAIntType
     /// </summary>
-    public enum DDAIntType
+    public enum DDAIntType : byte
     {
         DDAI_DeathsInRoom = 0,
         DDAI_MAX = 1,
@@ -1791,7 +1791,7 @@ public partial class RPersistentOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: POVersion
     /// </summary>
-    public enum POVersion
+    public enum POVersion : byte
     {
         POVer_Initial = 0,
         POVer_ChallengeData = 1,

--- a/src/BmSDK/Generated/BmGame/RPersistentShared.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPersistentShared.g.cs
@@ -1251,7 +1251,7 @@ public partial class RPersistentShared : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPercentData
     /// </summary>
-    public enum EPercentData
+    public enum EPercentData : byte
     {
         EPercentData_Grand = 0,
         EPercentData_Story = 1,
@@ -1310,7 +1310,7 @@ public partial class RPersistentShared : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGameplayStats
     /// </summary>
-    public enum EGameplayStats
+    public enum EGameplayStats : byte
     {
         EGameplayStats_DistanceFlown = 0,
         EGameplayStats_MAX = 1,
@@ -1319,7 +1319,7 @@ public partial class RPersistentShared : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: PSharedVersion
     /// </summary>
-    public enum PSharedVersion
+    public enum PSharedVersion : byte
     {
         PSharedVer_Initial = 0,
         PSharedVer_AddedNEWs = 1,

--- a/src/BmSDK/Generated/BmGame/RPhysUtil.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPhysUtil.g.cs
@@ -270,7 +270,7 @@ public partial class RPhysUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeMirroredType
     /// </summary>
-    public enum ECapeMirroredType
+    public enum ECapeMirroredType : byte
     {
         ECAPEMIRROREDTYPE_Unmirrored = 0,
         ECAPEMIRROREDTYPE_Mirrored = 1,
@@ -280,7 +280,7 @@ public partial class RPhysUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeHiddenType
     /// </summary>
-    public enum ECapeHiddenType
+    public enum ECapeHiddenType : byte
     {
         CAPEHIDDENTYPE_Leave = 0,
         CAPEHIDDENTYPE_Hide = 1,
@@ -292,7 +292,7 @@ public partial class RPhysUtil : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECapeEnabledType
     /// </summary>
-    public enum ECapeEnabledType
+    public enum ECapeEnabledType : byte
     {
         CAPEENABLEDTYPE_Leave = 0,
         CAPEENABLEDTYPE_Disable = 1,

--- a/src/BmSDK/Generated/BmGame/RPlayerController.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPlayerController.g.cs
@@ -14721,7 +14721,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: KismetBatmanStates
     /// </summary>
-    public enum KismetBatmanStates
+    public enum KismetBatmanStates : byte
     {
         KBS_Walking = 0,
         KBS_Falling = 1,
@@ -14746,7 +14746,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: GroundMovementState
     /// </summary>
-    public enum GroundMovementState
+    public enum GroundMovementState : byte
     {
         GMS_Walking = 0,
         GMS_RunningMove = 1,
@@ -14849,7 +14849,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: ETakedownFeature_Type
     /// </summary>
-    public enum ETakedownFeature_Type
+    public enum ETakedownFeature_Type : byte
     {
         TFT_Railing = 0,
         TFT_OnTopOfRailing = 1,
@@ -14861,7 +14861,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EPlayerTakedownType
     /// </summary>
-    public enum EPlayerTakedownType
+    public enum EPlayerTakedownType : byte
     {
         TKD_Generic = 0,
         TKD_AboveInFront = 1,
@@ -15009,7 +15009,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EDeviceScanType
     /// </summary>
-    public enum EDeviceScanType
+    public enum EDeviceScanType : byte
     {
         DST_WonderAutomaton = 0,
         DST_HelicopterController = 1,
@@ -15019,7 +15019,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EDeviceScanResult
     /// </summary>
-    public enum EDeviceScanResult
+    public enum EDeviceScanResult : byte
     {
         DSR_PlayerAborts = 0,
         DSR_DamageAborts = 1,
@@ -15037,7 +15037,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EBatmanPoisonLevel
     /// </summary>
-    public enum EBatmanPoisonLevel
+    public enum EBatmanPoisonLevel : byte
     {
         BPL_NoPoison = 0,
         BPL_PoisonMild = 1,
@@ -15160,7 +15160,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: RiddlerRowType
     /// </summary>
-    public enum RiddlerRowType
+    public enum RiddlerRowType : byte
     {
         RRT_Tape = 0,
         RRT_Concept = 1,
@@ -15170,7 +15170,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: RiddlerType
     /// </summary>
-    public enum RiddlerType
+    public enum RiddlerType : byte
     {
         RiddlerType_None = 0,
         RiddlerType_Batman = 1,
@@ -21413,7 +21413,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EGlideAttackTargettingType
     /// </summary>
-    public enum EGlideAttackTargettingType
+    public enum EGlideAttackTargettingType : byte
     {
         GATT_GlideAndDropAttack = 0,
         GATT_GlideAttackOnly = 1,
@@ -21425,7 +21425,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: EPCCheckFrame
     /// </summary>
-    public enum EPCCheckFrame
+    public enum EPCCheckFrame : byte
     {
         PCCF_InteractableItemFrame = 0,
         PCCF_StealthAttackTargetFrame = 1,
@@ -21436,7 +21436,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: JumpSpaceResult
     /// </summary>
-    public enum JumpSpaceResult
+    public enum JumpSpaceResult : byte
     {
         JSR_NoSpace = 0,
         JSR_NoGlide = 1,
@@ -21447,7 +21447,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: MapKeyType
     /// </summary>
-    public enum MapKeyType
+    public enum MapKeyType : byte
     {
         MK_Upgrades = 0,
         MK_Map = 1,
@@ -21462,7 +21462,7 @@ public partial class RPlayerController : BmSDK.BmGame.RPlayerControllerBase, BmS
     /// <summary>
     /// Enum: StealthAttackType
     /// </summary>
-    public enum StealthAttackType
+    public enum StealthAttackType : byte
     {
         SAT_SilentTakedown = 0,
         SAT_FearTakedown = 1,

--- a/src/BmSDK/Generated/BmGame/RPoseConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPoseConfig.g.cs
@@ -250,7 +250,7 @@ public partial class RPoseConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMirroredYesNoMaybe
     /// </summary>
-    public enum EMirroredYesNoMaybe
+    public enum EMirroredYesNoMaybe : byte
     {
         MYNM_No = 0,
         MYNM_Yes = 1,
@@ -792,7 +792,7 @@ public partial class RPoseConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMovementStyle
     /// </summary>
-    public enum EMovementStyle
+    public enum EMovementStyle : byte
     {
         MTS_Yaw = 0,
         MTS_Direction = 1,
@@ -864,7 +864,7 @@ public partial class RPoseConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMovementSpeed
     /// </summary>
-    public enum EMovementSpeed
+    public enum EMovementSpeed : byte
     {
         MS_WalkSlow = 0,
         MS_Walk = 1,

--- a/src/BmSDK/Generated/BmGame/RPredatorVolume.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPredatorVolume.g.cs
@@ -197,7 +197,7 @@ public partial class RPredatorVolume : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: PredatorAIType
     /// </summary>
-    public enum PredatorAIType
+    public enum PredatorAIType : byte
     {
         PRED_Minimal = 0,
         PRED_Lite = 1,

--- a/src/BmSDK/Generated/BmGame/RPresetAimingConfigs.g.cs
+++ b/src/BmSDK/Generated/BmGame/RPresetAimingConfigs.g.cs
@@ -225,7 +225,7 @@ public partial class RPresetAimingConfigs : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPresetAimingConfig
     /// </summary>
-    public enum EPresetAimingConfig
+    public enum EPresetAimingConfig : byte
     {
         PAC_None = 0,
         PAC_NoAiming = 1,

--- a/src/BmSDK/Generated/BmGame/RRagdollProcessor.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRagdollProcessor.g.cs
@@ -353,7 +353,7 @@ public partial class RRagdollProcessor : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: RagdollState
     /// </summary>
-    public enum RagdollState
+    public enum RagdollState : byte
     {
         RAG_Idle = 0,
         RAG_Ragdoll = 1,

--- a/src/BmSDK/Generated/BmGame/RRemoveableGrate.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRemoveableGrate.g.cs
@@ -706,7 +706,7 @@ public partial class RRemoveableGrate : BmSDK.BmGame.RSpecialMoveEnvironmentObje
     /// <summary>
     /// Enum: EGrateBoltPosition
     /// </summary>
-    public enum EGrateBoltPosition
+    public enum EGrateBoltPosition : byte
     {
         GBP_TopLeft = 0,
         GBP_TopRight = 1,
@@ -718,7 +718,7 @@ public partial class RRemoveableGrate : BmSDK.BmGame.RSpecialMoveEnvironmentObje
     /// <summary>
     /// Enum: EGrateRemoveType
     /// </summary>
-    public enum EGrateRemoveType
+    public enum EGrateRemoveType : byte
     {
         GRATEREMOVE_Loud = 0,
         GRATEREMOVE_Silent = 1,

--- a/src/BmSDK/Generated/BmGame/RRope2Component.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRope2Component.g.cs
@@ -1040,7 +1040,7 @@ public partial class RRope2Component : BmSDK.Engine.PrimitiveComponent, BmSDK.IG
     /// <summary>
     /// Enum: ERope2LengthChangeEndType
     /// </summary>
-    public enum ERope2LengthChangeEndType
+    public enum ERope2LengthChangeEndType : byte
     {
         ROPE2LENGTHCHANGEEND_ChangeFromEnd1 = 0,
         ROPE2LENGTHCHANGEEND_ChangeFromEnd2 = 1,
@@ -1051,7 +1051,7 @@ public partial class RRope2Component : BmSDK.Engine.PrimitiveComponent, BmSDK.IG
     /// <summary>
     /// Enum: ERope2EndType
     /// </summary>
-    public enum ERope2EndType
+    public enum ERope2EndType : byte
     {
         ROPE2END_End1 = 0,
         ROPE2END_End2 = 1,

--- a/src/BmSDK/Generated/BmGame/RRope2LengthUpdater.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRope2LengthUpdater.g.cs
@@ -171,7 +171,7 @@ public partial class RRope2LengthUpdater : BmSDK.BmGame.RRope2Updater, BmSDK.IGa
     /// <summary>
     /// Enum: ELengthChangeType
     /// </summary>
-    public enum ELengthChangeType
+    public enum ELengthChangeType : byte
     {
         LENGTHCHANGETYPE_Speed = 0,
         LENGTHCHANGETYPE_Linear = 1,

--- a/src/BmSDK/Generated/BmGame/RRope2SimplePhysicsControlPoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRope2SimplePhysicsControlPoint.g.cs
@@ -284,7 +284,7 @@ public partial class RRope2SimplePhysicsControlPoint : BmSDK.GameObject, BmSDK.I
     /// <summary>
     /// Enum: ControlPointPhysicsType
     /// </summary>
-    public enum ControlPointPhysicsType
+    public enum ControlPointPhysicsType : byte
     {
         ROPE2SIMPLECONTROLPOINTTYPE_Dynamic = 0,
         ROPE2SIMPLECONTROLPOINTTYPE_Fixed = 1,

--- a/src/BmSDK/Generated/BmGame/RRopeComponent.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRopeComponent.g.cs
@@ -470,7 +470,7 @@ public partial class RRopeComponent : BmSDK.BmGame.RRopeComponentBase, BmSDK.IGa
     /// <summary>
     /// Enum: ELoDUpdateMode
     /// </summary>
-    public enum ELoDUpdateMode
+    public enum ELoDUpdateMode : byte
     {
         LODUPDATEMODE_Normal = 0,
         LODUPDATEMODE_FixedLeafLength = 1,

--- a/src/BmSDK/Generated/BmGame/RRopeComponentBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRopeComponentBase.g.cs
@@ -926,7 +926,7 @@ public partial class RRopeComponentBase : BmSDK.Engine.PrimitiveComponent, BmSDK
     /// <summary>
     /// Enum: ERopeLengthControlType
     /// </summary>
-    public enum ERopeLengthControlType
+    public enum ERopeLengthControlType : byte
     {
         ROPELENGTHCONTROLTYPE_None = 0,
         ROPELENGTHCONTROLTYPE_GradualLengthChange = 1,
@@ -938,7 +938,7 @@ public partial class RRopeComponentBase : BmSDK.Engine.PrimitiveComponent, BmSDK
     /// <summary>
     /// Enum: ERopeLengthChangeType
     /// </summary>
-    public enum ERopeLengthChangeType
+    public enum ERopeLengthChangeType : byte
     {
         ROPELENGTHCHANGE_ChangeFromEnd1 = 0,
         ROPELENGTHCHANGE_ChangeFromEnd2 = 1,
@@ -952,7 +952,7 @@ public partial class RRopeComponentBase : BmSDK.Engine.PrimitiveComponent, BmSDK
     /// <summary>
     /// Enum: ERopeEndType
     /// </summary>
-    public enum ERopeEndType
+    public enum ERopeEndType : byte
     {
         ROPEEND_End1 = 0,
         ROPEEND_End2 = 1,

--- a/src/BmSDK/Generated/BmGame/RRopeTest.g.cs
+++ b/src/BmSDK/Generated/BmGame/RRopeTest.g.cs
@@ -282,7 +282,7 @@ public partial class RRopeTest : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERopeTestState
     /// </summary>
-    public enum ERopeTestState
+    public enum ERopeTestState : byte
     {
         ROPETEST_Wait = 0,
         ROPETEST_Initialise = 1,

--- a/src/BmSDK/Generated/BmGame/RSaveGameManager.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSaveGameManager.g.cs
@@ -417,7 +417,7 @@ public partial class RSaveGameManager : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: StorySlots
     /// </summary>
-    public enum StorySlots
+    public enum StorySlots : byte
     {
         StorySlot_Story = 0,
         StorySlot_Temp = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_ActivateElectrifiedFloorPanels.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_ActivateElectrifiedFloorPanels.g.cs
@@ -181,7 +181,7 @@ public partial class RSeqAct_ActivateElectrifiedFloorPanels : BmSDK.Engine.SeqAc
     /// <summary>
     /// Enum: StartUpType
     /// </summary>
-    public enum StartUpType
+    public enum StartUpType : byte
     {
         SUT_DistFromBats = 0,
         SUT_SameTime = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_CameraShake.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_CameraShake.g.cs
@@ -162,7 +162,7 @@ public partial class RSeqAct_CameraShake : BmSDK.Engine.SequenceAction, BmSDK.IG
     /// <summary>
     /// Enum: EScreenShakePreMades
     /// </summary>
-    public enum EScreenShakePreMades
+    public enum EScreenShakePreMades : byte
     {
         ESSPM_UseSpecifiedValues = 0,
         ESSPM_HitByBullet = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_CanSeePawn.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_CanSeePawn.g.cs
@@ -161,7 +161,7 @@ public partial class RSeqAct_CanSeePawn : BmSDK.Engine.SeqAct_Latent, BmSDK.IGam
     /// <summary>
     /// Enum: SightCheckResult
     /// </summary>
-    public enum SightCheckResult
+    public enum SightCheckResult : byte
     {
         SCR_Error = 0,
         SCR_NoChange = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_GFxMovieChallengeHUDControl.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_GFxMovieChallengeHUDControl.g.cs
@@ -128,7 +128,7 @@ public partial class RSeqAct_GFxMovieChallengeHUDControl : BmSDK.Engine.Sequence
     /// <summary>
     /// Enum: ChallengeHUDControl
     /// </summary>
-    public enum ChallengeHUDControl
+    public enum ChallengeHUDControl : byte
     {
         ChallengeHUDControl_KismetControlsHideShow = 0,
         ChallengeHUDControl_Show = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_GFxMovieExtraHUDControl.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_GFxMovieExtraHUDControl.g.cs
@@ -119,7 +119,7 @@ public partial class RSeqAct_GFxMovieExtraHUDControl : BmSDK.Engine.SequenceActi
     /// <summary>
     /// Enum: HUDControl
     /// </summary>
-    public enum HUDControl
+    public enum HUDControl : byte
     {
         HUDControl_KismetControlsHideShow = 0,
         HUDControl_Show = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_HudExtensionBossControl.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_HudExtensionBossControl.g.cs
@@ -101,7 +101,7 @@ public partial class RSeqAct_HudExtensionBossControl : BmSDK.Engine.SequenceActi
     /// <summary>
     /// Enum: BossHUDControl
     /// </summary>
-    public enum BossHUDControl
+    public enum BossHUDControl : byte
     {
         BHC_Show = 0,
         BHC_Hide = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_IceMeterBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_IceMeterBase.g.cs
@@ -499,7 +499,7 @@ public partial class RSeqAct_IceMeterBase : BmSDK.Engine.SeqAct_Latent, BmSDK.IG
     /// <summary>
     /// Enum: SoundMeterVolume
     /// </summary>
-    public enum SoundMeterVolume
+    public enum SoundMeterVolume : byte
     {
         CSMV_VeryQuiet = 0,
         CSMV_Quiet = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_PlayRandomLine.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_PlayRandomLine.g.cs
@@ -104,7 +104,7 @@ public partial class RSeqAct_PlayRandomLine : BmSDK.Engine.SeqAct_Latent, BmSDK.
     /// <summary>
     /// Enum: eRandomLineState
     /// </summary>
-    public enum eRandomLineState
+    public enum eRandomLineState : byte
     {
         eRandomLine_None = 0,
         eRandomLine_LoadPackage = 1,
@@ -120,7 +120,7 @@ public partial class RSeqAct_PlayRandomLine : BmSDK.Engine.SeqAct_Latent, BmSDK.
     /// <summary>
     /// Enum: WhichSpeaker
     /// </summary>
-    public enum WhichSpeaker
+    public enum WhichSpeaker : byte
     {
         Speaker_Any = 0,
         Speaker_Thug = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_PlaySpeechBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_PlaySpeechBase.g.cs
@@ -238,7 +238,7 @@ public partial class RSeqAct_PlaySpeechBase : BmSDK.Engine.SeqAct_Latent, BmSDK.
     /// <summary>
     /// Enum: EDialogueType
     /// </summary>
-    public enum EDialogueType
+    public enum EDialogueType : byte
     {
         DT_Normal = 0,
         DT_Cutscene = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_RasBossLogicBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_RasBossLogicBase.g.cs
@@ -819,7 +819,7 @@ public partial class RSeqAct_RasBossLogicBase : BmSDK.BmGame.RSeqAct_CombatSpawn
     /// <summary>
     /// Enum: RasSpeech
     /// </summary>
-    public enum RasSpeech
+    public enum RasSpeech : byte
     {
         RSSP_Intro = 0,
         RSSP_ArmyAngry = 1,
@@ -856,7 +856,7 @@ public partial class RSeqAct_RasBossLogicBase : BmSDK.BmGame.RSeqAct_CombatSpawn
     /// <summary>
     /// Enum: ERasStage
     /// </summary>
-    public enum ERasStage
+    public enum ERasStage : byte
     {
         RS_Sand = 0,
         RS_Mano = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SetChapter.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SetChapter.g.cs
@@ -108,7 +108,7 @@ public partial class RSeqAct_SetChapter : BmSDK.Engine.SequenceAction, BmSDK.IGa
     /// <summary>
     /// Enum: ESubChapter
     /// </summary>
-    public enum ESubChapter
+    public enum ESubChapter : byte
     {
         ESubChapter_None = 0,
         ESubChapter_a = 1,
@@ -143,7 +143,7 @@ public partial class RSeqAct_SetChapter : BmSDK.Engine.SequenceAction, BmSDK.IGa
     /// <summary>
     /// Enum: ESideStory
     /// </summary>
-    public enum ESideStory
+    public enum ESideStory : byte
     {
         ESideStory_None = 0,
         ESideStory_Azrael = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SetSimultaneousCounters.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SetSimultaneousCounters.g.cs
@@ -112,7 +112,7 @@ public partial class RSeqAct_SetSimultaneousCounters : BmSDK.Engine.SequenceActi
     /// <summary>
     /// Enum: SCounterSize
     /// </summary>
-    public enum SCounterSize
+    public enum SCounterSize : byte
     {
         SCS_Off = 0,
         SCS_UpTo2 = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SmashablePropChange.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SmashablePropChange.g.cs
@@ -128,7 +128,7 @@ public partial class RSeqAct_SmashablePropChange : BmSDK.Engine.SequenceAction, 
     /// <summary>
     /// Enum: ESmashablePropChangeType
     /// </summary>
-    public enum ESmashablePropChangeType
+    public enum ESmashablePropChangeType : byte
     {
         SMASHABLEPROPCHANGE_TriggerBreakProp = 0,
         SMASHABLEPROPCHANGE_TurnStaticOnStationary = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SpeechEventManagerBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SpeechEventManagerBase.g.cs
@@ -255,7 +255,7 @@ public partial class RSeqAct_SpeechEventManagerBase : BmSDK.BmGame.RSeqAct_PlayS
     /// <summary>
     /// Enum: SpeechLinesOrder
     /// </summary>
-    public enum SpeechLinesOrder
+    public enum SpeechLinesOrder : byte
     {
         SL_Random = 0,
         SL_InOrder = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SwitchDate.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SwitchDate.g.cs
@@ -178,7 +178,7 @@ public partial class RSeqAct_SwitchDate : BmSDK.Engine.SequenceAction, BmSDK.IGa
     /// <summary>
     /// Enum: EMonth
     /// </summary>
-    public enum EMonth
+    public enum EMonth : byte
     {
         Month_January = 0,
         Month_Febuary = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_SwitchFlags.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_SwitchFlags.g.cs
@@ -81,7 +81,7 @@ public partial class RSeqAct_SwitchFlags : BmSDK.Engine.SequenceAction, BmSDK.IG
     /// <summary>
     /// Enum: SFModeType
     /// </summary>
-    public enum SFModeType
+    public enum SFModeType : byte
     {
         SFMode_All_True = 0,
         SFMode_All_False = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqAct_TutorialLookAt.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqAct_TutorialLookAt.g.cs
@@ -125,7 +125,7 @@ public partial class RSeqAct_TutorialLookAt : BmSDK.Engine.SeqAct_Latent, BmSDK.
     /// <summary>
     /// Enum: ETutorialLookAtState
     /// </summary>
-    public enum ETutorialLookAtState
+    public enum ETutorialLookAtState : byte
     {
         TLAS_WaitingToLookAt = 0,
         TLAS_LookAt = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqEvent_CustomBackscreenRequested.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqEvent_CustomBackscreenRequested.g.cs
@@ -103,7 +103,7 @@ public partial class RSeqEvent_CustomBackscreenRequested : BmSDK.Engine.Sequence
     /// <summary>
     /// Enum: BackscreenAvailability
     /// </summary>
-    public enum BackscreenAvailability
+    public enum BackscreenAvailability : byte
     {
         BA_NotAvailableAbort = 0,
         BA_NotAvailableContinue = 1,

--- a/src/BmSDK/Generated/BmGame/RSeqEvent_HelicopterAggroStateChanged.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSeqEvent_HelicopterAggroStateChanged.g.cs
@@ -92,7 +92,7 @@ public partial class RSeqEvent_HelicopterAggroStateChanged : BmSDK.Engine.Sequen
     /// <summary>
     /// Enum: HeliAggroState
     /// </summary>
-    public enum HeliAggroState
+    public enum HeliAggroState : byte
     {
         HD_HelicopterAggroed = 0,
         HD_SafeFromHelicopters = 1,

--- a/src/BmSDK/Generated/BmGame/RSmashablePropConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSmashablePropConfig.g.cs
@@ -81,7 +81,7 @@ public partial class RSmashablePropConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObj
     /// <summary>
     /// Enum: PropKOType
     /// </summary>
-    public enum PropKOType
+    public enum PropKOType : byte
     {
         KO_None = 0,
         KO_Window = 1,
@@ -357,7 +357,7 @@ public partial class RSmashablePropConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObj
     /// <summary>
     /// Enum: EBreakableType
     /// </summary>
-    public enum EBreakableType
+    public enum EBreakableType : byte
     {
         BREAKABLETYPE_ForceBreakable = 0,
         BREAKABLETYPE_PawnForceBreakable = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig.g.cs
@@ -114,7 +114,7 @@ public partial class RSpecialMoveConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObjec
     /// <summary>
     /// Enum: AISpecialMoveCommentType
     /// </summary>
-    public enum AISpecialMoveCommentType
+    public enum AISpecialMoveCommentType : byte
     {
         SMCT_NoComment = 0,
         SMCT_JumpRailing = 1,
@@ -125,7 +125,7 @@ public partial class RSpecialMoveConfig : BmSDK.BmGame.RConfig, BmSDK.IGameObjec
     /// <summary>
     /// Enum: ESpecialMoveAnimSetType
     /// </summary>
-    public enum ESpecialMoveAnimSetType
+    public enum ESpecialMoveAnimSetType : byte
     {
         SMAT_LadderAnims = 0,
         SMAT_GrateRipAnims = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_GlideKick.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_GlideKick.g.cs
@@ -81,7 +81,7 @@ public partial class RSpecialMoveConfig_GlideKick : BmSDK.BmGame.RSpecialMoveCon
     /// <summary>
     /// Enum: EGlideKickMoveExtraInfo
     /// </summary>
-    public enum EGlideKickMoveExtraInfo
+    public enum EGlideKickMoveExtraInfo : byte
     {
         GKMEI_GlideVelocity = 0,
         GKMEI_MAX = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_Interrogation.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_Interrogation.g.cs
@@ -81,7 +81,7 @@ public partial class RSpecialMoveConfig_Interrogation : BmSDK.BmGame.RSpecialMov
     /// <summary>
     /// Enum: CameraCollisionOption
     /// </summary>
-    public enum CameraCollisionOption
+    public enum CameraCollisionOption : byte
     {
         CCO_None = 0,
         CCO_Player = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_RelativeAnimMove.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_RelativeAnimMove.g.cs
@@ -134,7 +134,7 @@ public partial class RSpecialMoveConfig_RelativeAnimMove : BmSDK.BmGame.RSpecial
     /// <summary>
     /// Enum: ERelativeAnimMoveExtraInfo
     /// </summary>
-    public enum ERelativeAnimMoveExtraInfo
+    public enum ERelativeAnimMoveExtraInfo : byte
     {
         ERAMEI_FreeRotation = 0,
         ERAMEI_MAX = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_RunningRelativeAnimMove.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_RunningRelativeAnimMove.g.cs
@@ -144,7 +144,7 @@ public partial class RSpecialMoveConfig_RunningRelativeAnimMove : BmSDK.BmGame.R
     /// <summary>
     /// Enum: RelativeAnimLaunchFoot
     /// </summary>
-    public enum RelativeAnimLaunchFoot
+    public enum RelativeAnimLaunchFoot : byte
     {
         RALF_LeftFoot = 0,
         RALF_RightFoot = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_Shimmy.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_Shimmy.g.cs
@@ -135,7 +135,7 @@ public partial class RSpecialMoveConfig_Shimmy : BmSDK.BmGame.RSpecialMoveConfig
     /// <summary>
     /// Enum: EShimmyDir
     /// </summary>
-    public enum EShimmyDir
+    public enum EShimmyDir : byte
     {
         SD_NoShimmy = 0,
         SD_ShimmyLeft = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_SwingToVantagePoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveConfig_SwingToVantagePoint.g.cs
@@ -81,7 +81,7 @@ public partial class RSpecialMoveConfig_SwingToVantagePoint : BmSDK.BmGame.RSpec
     /// <summary>
     /// Enum: ESwingToVantagePointExtraInfo
     /// </summary>
-    public enum ESwingToVantagePointExtraInfo
+    public enum ESwingToVantagePointExtraInfo : byte
     {
         STVPEI_GrappleTarget = 0,
         STVPEI_MAX = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_HarpoonBase.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_HarpoonBase.g.cs
@@ -255,7 +255,7 @@ public partial class RSpecialMoveInstance_HarpoonBase : BmSDK.BmGame.RSpecialMov
     /// <summary>
     /// Enum: BatclawRopeHandOn
     /// </summary>
-    public enum BatclawRopeHandOn
+    public enum BatclawRopeHandOn : byte
     {
         BRHO_NoHand = 0,
         BRHO_LeftHand = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_Interrogation.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_Interrogation.g.cs
@@ -619,7 +619,7 @@ public partial class RSpecialMoveInstance_Interrogation : BmSDK.BmGame.RSpecialM
     /// <summary>
     /// Enum: InterrogationThugReaction
     /// </summary>
-    public enum InterrogationThugReaction
+    public enum InterrogationThugReaction : byte
     {
         ITR_None = 0,
         ITR_Yes = 1,

--- a/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_LineLauncher.g.cs
+++ b/src/BmSDK/Generated/BmGame/RSpecialMoveInstance_LineLauncher.g.cs
@@ -583,7 +583,7 @@ public partial class RSpecialMoveInstance_LineLauncher : BmSDK.BmGame.RSpecialMo
     /// <summary>
     /// Enum: LineLauncherTakedownFinish
     /// </summary>
-    public enum LineLauncherTakedownFinish
+    public enum LineLauncherTakedownFinish : byte
     {
         LLFM_Drop = 0,
         LLFM_WallSlam = 1,
@@ -594,7 +594,7 @@ public partial class RSpecialMoveInstance_LineLauncher : BmSDK.BmGame.RSpecialMo
     /// <summary>
     /// Enum: LineLauncherGrabType
     /// </summary>
-    public enum LineLauncherGrabType
+    public enum LineLauncherGrabType : byte
     {
         LLGT_GrabLeft = 0,
         LLGT_GrabRight = 1,
@@ -604,7 +604,7 @@ public partial class RSpecialMoveInstance_LineLauncher : BmSDK.BmGame.RSpecialMo
     /// <summary>
     /// Enum: LineLauncherDismountType
     /// </summary>
-    public enum LineLauncherDismountType
+    public enum LineLauncherDismountType : byte
     {
         LLDT_None = 0,
         LLDT_Land = 1,
@@ -617,7 +617,7 @@ public partial class RSpecialMoveInstance_LineLauncher : BmSDK.BmGame.RSpecialMo
     /// <summary>
     /// Enum: LineLauncherMovementResult
     /// </summary>
-    public enum LineLauncherMovementResult
+    public enum LineLauncherMovementResult : byte
     {
         LLMR_AllFine = 0,
         LLMR_HitObstacle = 1,
@@ -629,7 +629,7 @@ public partial class RSpecialMoveInstance_LineLauncher : BmSDK.BmGame.RSpecialMo
     /// <summary>
     /// Enum: LineLauncherKickDirection
     /// </summary>
-    public enum LineLauncherKickDirection
+    public enum LineLauncherKickDirection : byte
     {
         LLKD_ForwardKick = 0,
         LLKD_LeftKick = 1,

--- a/src/BmSDK/Generated/BmGame/RStartlePoint.g.cs
+++ b/src/BmSDK/Generated/BmGame/RStartlePoint.g.cs
@@ -103,7 +103,7 @@ public partial class RStartlePoint : BmSDK.BmGame.RDummyTarget, BmSDK.IGameObjec
     /// <summary>
     /// Enum: StartleType
     /// </summary>
-    public enum StartleType
+    public enum StartleType : byte
     {
         ST_Furnace = 0,
         ST_FreezeVent = 1,

--- a/src/BmSDK/Generated/BmGame/RStealthTakeDownStage.g.cs
+++ b/src/BmSDK/Generated/BmGame/RStealthTakeDownStage.g.cs
@@ -1092,7 +1092,7 @@ public partial class RStealthTakeDownStage : BmSDK.Engine.Actor, BmSDK.IGameObje
     /// <summary>
     /// Enum: AttackApproachDirection
     /// </summary>
-    public enum AttackApproachDirection
+    public enum AttackApproachDirection : byte
     {
         AAP_Back = 0,
         AAP_Front = 1,

--- a/src/BmSDK/Generated/BmGame/RStealthTakeDownStage_GlassWallAttack.g.cs
+++ b/src/BmSDK/Generated/BmGame/RStealthTakeDownStage_GlassWallAttack.g.cs
@@ -303,7 +303,7 @@ public partial class RStealthTakeDownStage_GlassWallAttack : BmSDK.BmGame.RSteal
     /// <summary>
     /// Enum: CameraCollisionOption
     /// </summary>
-    public enum CameraCollisionOption
+    public enum CameraCollisionOption : byte
     {
         CCO_None = 0,
         CCO_Player = 1,

--- a/src/BmSDK/Generated/BmGame/RThrowTarget.g.cs
+++ b/src/BmSDK/Generated/BmGame/RThrowTarget.g.cs
@@ -126,7 +126,7 @@ public partial class RThrowTarget : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EThrowTargetPriority
     /// </summary>
-    public enum EThrowTargetPriority
+    public enum EThrowTargetPriority : byte
     {
         ETTP_Low = 0,
         ETTP_High = 1,

--- a/src/BmSDK/Generated/BmGame/RTunnelFunnel.g.cs
+++ b/src/BmSDK/Generated/BmGame/RTunnelFunnel.g.cs
@@ -117,7 +117,7 @@ public partial class RTunnelFunnel : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: TunnelFunnelType
     /// </summary>
-    public enum TunnelFunnelType
+    public enum TunnelFunnelType : byte
     {
         ETFT_BothDirections = 0,
         ETFT_LeftOnly = 1,

--- a/src/BmSDK/Generated/BmScript/RBMBehaviour_CombatLunatic.g.cs
+++ b/src/BmSDK/Generated/BmScript/RBMBehaviour_CombatLunatic.g.cs
@@ -199,7 +199,7 @@ public partial class RBMBehaviour_CombatLunatic : BmSDK.BmGame.RBMBehaviour_Comb
     /// <summary>
     /// Enum: LunaticMoveState
     /// </summary>
-    public enum LunaticMoveState
+    public enum LunaticMoveState : byte
     {
         LMS_Walk = 0,
         LMS_Jump = 1,

--- a/src/BmSDK/Generated/BmScript/RBMBehaviour_Freeze.g.cs
+++ b/src/BmSDK/Generated/BmScript/RBMBehaviour_Freeze.g.cs
@@ -1805,7 +1805,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: RoomAttackStrategies
     /// </summary>
-    public enum RoomAttackStrategies
+    public enum RoomAttackStrategies : byte
     {
         RAS_FreezeTheAir = 0,
         RAS_MAX = 1,
@@ -1814,7 +1814,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: RoomAttackStates
     /// </summary>
-    public enum RoomAttackStates
+    public enum RoomAttackStates : byte
     {
         RA_PrepareAttack = 0,
         RA_SuitEffect = 1,
@@ -1828,7 +1828,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: WeaponSequenceStates
     /// </summary>
-    public enum WeaponSequenceStates
+    public enum WeaponSequenceStates : byte
     {
         WS_TakeAim = 0,
         WS_PauseForDrama = 1,
@@ -1841,7 +1841,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: AttackPointSearchStates
     /// </summary>
-    public enum AttackPointSearchStates
+    public enum AttackPointSearchStates : byte
     {
         AP_Idle = 0,
         AP_FindPoints = 1,
@@ -1853,7 +1853,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: EnvNeutStrategy
     /// </summary>
-    public enum EnvNeutStrategy
+    public enum EnvNeutStrategy : byte
     {
         ENS_SilentTakedown = 0,
         ENS_RailsLedges = 1,
@@ -1872,7 +1872,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: FreezeWeapon
     /// </summary>
-    public enum FreezeWeapon
+    public enum FreezeWeapon : byte
     {
         FW_Repel = 0,
         FW_FreezeGun = 1,
@@ -1885,7 +1885,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: NavigationApproach
     /// </summary>
-    public enum NavigationApproach
+    public enum NavigationApproach : byte
     {
         NA_MoveToPosition = 0,
         NA_MoveNearToPosition = 1,
@@ -1896,7 +1896,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: NavigationStrategy
     /// </summary>
-    public enum NavigationStrategy
+    public enum NavigationStrategy : byte
     {
         NS_None = 0,
         NS_MoveToBatmansPosition = 1,
@@ -1911,7 +1911,7 @@ public partial class RBMBehaviour_Freeze : BmSDK.BmGame.RBMBehaviour, BmSDK.IGam
     /// <summary>
     /// Enum: DiffLevel
     /// </summary>
-    public enum DiffLevel
+    public enum DiffLevel : byte
     {
         DL_EASY = 0,
         DL_NORMAL = 1,

--- a/src/BmSDK/Generated/BmScript/RExplosionLight.g.cs
+++ b/src/BmSDK/Generated/BmScript/RExplosionLight.g.cs
@@ -116,7 +116,7 @@ public partial class RExplosionLight : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELifeType
     /// </summary>
-    public enum ELifeType
+    public enum ELifeType : byte
     {
         EL_None = 0,
         EL_FastStartSlowEnd = 1,

--- a/src/BmSDK/Generated/BmScript/RFreezeEnvironmentTarget.g.cs
+++ b/src/BmSDK/Generated/BmScript/RFreezeEnvironmentTarget.g.cs
@@ -327,7 +327,7 @@ public partial class RFreezeEnvironmentTarget : BmSDK.Engine.Actor, BmSDK.IGameO
     /// <summary>
     /// Enum: FreezeEnvTargetType
     /// </summary>
-    public enum FreezeEnvTargetType
+    public enum FreezeEnvTargetType : byte
     {
         FET_NONE = 0,
         FET_RailLedge = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_DLC_OfferCatwoman.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_DLC_OfferCatwoman.g.cs
@@ -138,7 +138,7 @@ public partial class RGFxMovieUI_DLC_OfferCatwoman : BmSDK.BmGame.RGFxMovieUI, B
     /// <summary>
     /// Enum: CWOPopTypes
     /// </summary>
-    public enum CWOPopTypes
+    public enum CWOPopTypes : byte
     {
         CWOPopType_None = 0,
         CWOPopType_GoToStore = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_DifficultySelect.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_DifficultySelect.g.cs
@@ -174,7 +174,7 @@ public partial class RGFxMovieUI_DifficultySelect : BmSDK.BmGame.RGFxMovieUI, Bm
     /// <summary>
     /// Enum: GODifficultyMenuItem
     /// </summary>
-    public enum GODifficultyMenuItem
+    public enum GODifficultyMenuItem : byte
     {
         GODMI_None = 0,
         GODMI_Difficulty = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_MainMenu.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_MainMenu.g.cs
@@ -571,7 +571,7 @@ public partial class RGFxMovieUI_MainMenu : BmSDK.BmGame.RGFxMovieUI, BmSDK.IGam
     /// <summary>
     /// Enum: MMHeadedTo
     /// </summary>
-    public enum MMHeadedTo
+    public enum MMHeadedTo : byte
     {
         MMHeadedNowhere = 0,
         MMHeadedToPSN = 1,
@@ -582,7 +582,7 @@ public partial class RGFxMovieUI_MainMenu : BmSDK.BmGame.RGFxMovieUI, BmSDK.IGam
     /// <summary>
     /// Enum: MMPopTypes
     /// </summary>
-    public enum MMPopTypes
+    public enum MMPopTypes : byte
     {
         MMPopType_None = 0,
         MMPopType_Exit = 1,
@@ -604,7 +604,7 @@ public partial class RGFxMovieUI_MainMenu : BmSDK.BmGame.RGFxMovieUI, BmSDK.IGam
     /// <summary>
     /// Enum: MainMenuItems
     /// </summary>
-    public enum MainMenuItems
+    public enum MainMenuItems : byte
     {
         MMI_None = 0,
         MMI_NewGame = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_Options3D.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_Options3D.g.cs
@@ -162,7 +162,7 @@ public partial class RGFxMovieUI_Options3D : BmSDK.BmGame.RGFxMovieUI, BmSDK.IGa
     /// <summary>
     /// Enum: GOMenuItem
     /// </summary>
-    public enum GOMenuItem
+    public enum GOMenuItem : byte
     {
         TVOMI_None = 0,
         TVOMI_Mode3D = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_Options3DTV.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_Options3DTV.g.cs
@@ -162,7 +162,7 @@ public partial class RGFxMovieUI_Options3DTV : BmSDK.BmGame.RGFxMovieUI, BmSDK.I
     /// <summary>
     /// Enum: GOMenuItem
     /// </summary>
-    public enum GOMenuItem
+    public enum GOMenuItem : byte
     {
         TV3OMI_None = 0,
         TV3OMI_Mode3D = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsAudio.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsAudio.g.cs
@@ -139,7 +139,7 @@ public partial class RGFxMovieUI_OptionsAudio : BmSDK.BmGame.RGFxMovieUI, BmSDK.
     /// <summary>
     /// Enum: GOMenuItem
     /// </summary>
-    public enum GOMenuItem
+    public enum GOMenuItem : byte
     {
         AOMI_None = 0,
         AOMI_Subtitles = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsGame.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsGame.g.cs
@@ -214,7 +214,7 @@ public partial class RGFxMovieUI_OptionsGame : BmSDK.BmGame.RGFxMovieUI, BmSDK.I
     /// <summary>
     /// Enum: GOMenuItem
     /// </summary>
-    public enum GOMenuItem
+    public enum GOMenuItem : byte
     {
         GOMI_None = 0,
         GOMI_InvertLook = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsMenu.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_OptionsMenu.g.cs
@@ -139,7 +139,7 @@ public partial class RGFxMovieUI_OptionsMenu : BmSDK.BmGame.RGFxMovieUI, BmSDK.I
     /// <summary>
     /// Enum: OptionsMenuItems
     /// </summary>
-    public enum OptionsMenuItems
+    public enum OptionsMenuItems : byte
     {
         MMI_None = 0,
         MMI_OptionsGame = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_RiddlerModeSelect.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_RiddlerModeSelect.g.cs
@@ -282,7 +282,7 @@ public partial class RGFxMovieUI_RiddlerModeSelect : BmSDK.BmGame.RGFxMovieUI, B
     /// <summary>
     /// Enum: RMMPopTypes
     /// </summary>
-    public enum RMMPopTypes
+    public enum RMMPopTypes : byte
     {
         RMMPopType_None = 0,
         RMMPopType_SignIn = 1,
@@ -293,7 +293,7 @@ public partial class RGFxMovieUI_RiddlerModeSelect : BmSDK.BmGame.RGFxMovieUI, B
     /// <summary>
     /// Enum: RiddlerModeItems
     /// </summary>
-    public enum RiddlerModeItems
+    public enum RiddlerModeItems : byte
     {
         RMT_None = 0,
         RMT_Ranked = 1,

--- a/src/BmSDK/Generated/BmScript/RGFxMovieUI_SaveSlotSelect.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGFxMovieUI_SaveSlotSelect.g.cs
@@ -315,7 +315,7 @@ public partial class RGFxMovieUI_SaveSlotSelect : BmSDK.BmGame.RGFxMovieUI, BmSD
     /// <summary>
     /// Enum: SavePopupType
     /// </summary>
-    public enum SavePopupType
+    public enum SavePopupType : byte
     {
         SavePopupType_FreeSpace = 0,
         SavePopupType_Delete = 1,

--- a/src/BmSDK/Generated/BmScript/RGrundyDrumPad.g.cs
+++ b/src/BmSDK/Generated/BmScript/RGrundyDrumPad.g.cs
@@ -271,7 +271,7 @@ public partial class RGrundyDrumPad : BmSDK.BmGame.RGrundyDrumPadBase, BmSDK.IGa
     /// <summary>
     /// Enum: eDrumPadAnims
     /// </summary>
-    public enum eDrumPadAnims
+    public enum eDrumPadAnims : byte
     {
         eDPA_Closed_Idle = 0,
         eDPA_Open = 1,
@@ -283,7 +283,7 @@ public partial class RGrundyDrumPad : BmSDK.BmGame.RGrundyDrumPadBase, BmSDK.IGa
     /// <summary>
     /// Enum: eDrumPadLightStates
     /// </summary>
-    public enum eDrumPadLightStates
+    public enum eDrumPadLightStates : byte
     {
         eDPLS_Idle = 0,
         eDPLS_Charging = 1,

--- a/src/BmSDK/Generated/BmScript/RHelicopter.g.cs
+++ b/src/BmSDK/Generated/BmScript/RHelicopter.g.cs
@@ -1107,7 +1107,7 @@ public partial class RHelicopter : BmSDK.BmGame.RHelicopterBase, BmSDK.BmGame.RB
     /// <summary>
     /// Enum: ELightColour
     /// </summary>
-    public enum ELightColour
+    public enum ELightColour : byte
     {
         ELC_White = 0,
         ELC_Red = 1,
@@ -1117,7 +1117,7 @@ public partial class RHelicopter : BmSDK.BmGame.RHelicopterBase, BmSDK.BmGame.RB
     /// <summary>
     /// Enum: HeliHighlightType
     /// </summary>
-    public enum HeliHighlightType
+    public enum HeliHighlightType : byte
     {
         HHT_STANDARD = 0,
         HHT_SCANNABLE = 1,
@@ -1129,7 +1129,7 @@ public partial class RHelicopter : BmSDK.BmGame.RHelicopterBase, BmSDK.BmGame.RB
     /// <summary>
     /// Enum: HeliAttackMode
     /// </summary>
-    public enum HeliAttackMode
+    public enum HeliAttackMode : byte
     {
         HAM_NOT_SHOOTING = 0,
         HAM_SPIN_UP_CHAINGUN = 1,

--- a/src/BmSDK/Generated/BmScript/RMagneticBeamAttractor.g.cs
+++ b/src/BmSDK/Generated/BmScript/RMagneticBeamAttractor.g.cs
@@ -188,7 +188,7 @@ public partial class RMagneticBeamAttractor : BmSDK.BmGame.RDummyTarget, BmSDK.B
     /// <summary>
     /// Enum: EBeamDirection
     /// </summary>
-    public enum EBeamDirection
+    public enum EBeamDirection : byte
     {
         BD_Any = 0,
         BD_OnlyForward = 1,

--- a/src/BmSDK/Generated/BmScript/RMagneticDoor.g.cs
+++ b/src/BmSDK/Generated/BmScript/RMagneticDoor.g.cs
@@ -417,7 +417,7 @@ public partial class RMagneticDoor : BmSDK.BmGame.RMagneticDynamicObjectSkeletal
     /// <summary>
     /// Enum: EShutterDoorState
     /// </summary>
-    public enum EShutterDoorState
+    public enum EShutterDoorState : byte
     {
         ESDS_Open = 0,
         ESDS_Closed = 1,
@@ -428,7 +428,7 @@ public partial class RMagneticDoor : BmSDK.BmGame.RMagneticDynamicObjectSkeletal
     /// <summary>
     /// Enum: EAttractAxis
     /// </summary>
-    public enum EAttractAxis
+    public enum EAttractAxis : byte
     {
         EAA_None = 0,
         EAA_Positive_X = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnBossClayface.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnBossClayface.g.cs
@@ -3914,7 +3914,7 @@ public partial class RPawnBossClayface : BmSDK.BmGame.RPawnBossClayfaceBase, BmS
     /// <summary>
     /// Enum: ClayStages
     /// </summary>
-    public enum ClayStages
+    public enum ClayStages : byte
     {
         CT_Stage1 = 0,
         CT_Stage2 = 1,
@@ -3926,7 +3926,7 @@ public partial class RPawnBossClayface : BmSDK.BmGame.RPawnBossClayfaceBase, BmS
     /// <summary>
     /// Enum: AttackTypes
     /// </summary>
-    public enum AttackTypes
+    public enum AttackTypes : byte
     {
         AT_NonSelected = 0,
         AT_GroundProjectile = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnBossDeadshot.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnBossDeadshot.g.cs
@@ -493,7 +493,7 @@ public partial class RPawnBossDeadshot : BmSDK.BmGame.RPawnBossDeadshotBase, BmS
     /// <summary>
     /// Enum: EDSTurnDir
     /// </summary>
-    public enum EDSTurnDir
+    public enum EDSTurnDir : byte
     {
         EDS_Left = 0,
         EDS_Right = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnBossGrundy.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnBossGrundy.g.cs
@@ -2352,7 +2352,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: eSwingRumbleState
     /// </summary>
-    public enum eSwingRumbleState
+    public enum eSwingRumbleState : byte
     {
         ESRR_OutOfRange = 0,
         ESRR_Weak = 1,
@@ -2363,7 +2363,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: eGrundyVeinColourScheme
     /// </summary>
-    public enum eGrundyVeinColourScheme
+    public enum eGrundyVeinColourScheme : byte
     {
         eGVCS = 0,
         eGVCS_2 = 1,
@@ -2375,7 +2375,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: eGrundyHelpTextState
     /// </summary>
-    public enum eGrundyHelpTextState
+    public enum eGrundyHelpTextState : byte
     {
         eGHTS_None = 0,
         eGHTS_Gel = 1,
@@ -2414,7 +2414,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: eGrundyBeatMatch
     /// </summary>
-    public enum eGrundyBeatMatch
+    public enum eGrundyBeatMatch : byte
     {
         eGBM_BEFORE = 0,
         eGBM_AFTER = 1,
@@ -2634,7 +2634,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: E_SwingChainState
     /// </summary>
-    public enum E_SwingChainState
+    public enum E_SwingChainState : byte
     {
         E_SwingChainState_Anim = 0,
         E_SwingChainState_ToBM = 1,
@@ -5455,7 +5455,7 @@ public partial class RPawnBossGrundy : BmSDK.BmGame.RPawnBossGrundyBase, BmSDK.I
     /// <summary>
     /// Enum: eGrundyMeshGlowiness
     /// </summary>
-    public enum eGrundyMeshGlowiness
+    public enum eGrundyMeshGlowiness : byte
     {
         eGMG_Opaque = 0,
         eGMG_EmissiveOnly = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnPlayerCatwoman.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnPlayerCatwoman.g.cs
@@ -1324,7 +1324,7 @@ public partial class RPawnPlayerCatwoman : BmSDK.BmGame.RPawnPlayerCatwomanBase,
     /// <summary>
     /// Enum: ECatwomanGadgetList
     /// </summary>
-    public enum ECatwomanGadgetList
+    public enum ECatwomanGadgetList : byte
     {
         CWGL_BullWhip = 0,
         CWGL_Bolas = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnPlayerNightwing.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnPlayerNightwing.g.cs
@@ -1113,7 +1113,7 @@ public partial class RPawnPlayerNightwing : BmSDK.BmGame.RPawnPlayerNightwingBas
     /// <summary>
     /// Enum: ENightwingGadgetList
     /// </summary>
-    public enum ENightwingGadgetList
+    public enum ENightwingGadgetList : byte
     {
         NWGL_Batarang = 0,
         NWGL_SticksAreaStun = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnPlayerRobin.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnPlayerRobin.g.cs
@@ -959,7 +959,7 @@ public partial class RPawnPlayerRobin : BmSDK.BmGame.RPawnPlayerBmBase, BmSDK.Bm
     /// <summary>
     /// Enum: ETypesOfExplodingThing
     /// </summary>
-    public enum ETypesOfExplodingThing
+    public enum ETypesOfExplodingThing : byte
     {
         TET_StickyBomb = 0,
         TET_Grenade = 1,
@@ -972,7 +972,7 @@ public partial class RPawnPlayerRobin : BmSDK.BmGame.RPawnPlayerBmBase, BmSDK.Bm
     /// <summary>
     /// Enum: ERobinGadgetList
     /// </summary>
-    public enum ERobinGadgetList
+    public enum ERobinGadgetList : byte
     {
         RGL_Batarang = 0,
         RGL_Staff = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnPlayerRobinStoryDLC.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnPlayerRobinStoryDLC.g.cs
@@ -418,7 +418,7 @@ public partial class RPawnPlayerRobinStoryDLC : BmSDK.BmScript.RPawnPlayerRobin,
     /// <summary>
     /// Enum: PDLCProgress
     /// </summary>
-    public enum PDLCProgress
+    public enum PDLCProgress : byte
     {
         PDLCP_ZipKicks = 0,
         PDLCP_ShieldBashes = 1,

--- a/src/BmSDK/Generated/BmScript/RPawnVillainFreeze.g.cs
+++ b/src/BmSDK/Generated/BmScript/RPawnVillainFreeze.g.cs
@@ -2363,7 +2363,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: BatmanDialogueLines
     /// </summary>
-    public enum BatmanDialogueLines
+    public enum BatmanDialogueLines : byte
     {
         BDL_FailedGlide = 0,
         BDL_DropFromFrozen = 1,
@@ -2376,7 +2376,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: FreezeDialogueLines
     /// </summary>
-    public enum FreezeDialogueLines
+    public enum FreezeDialogueLines : byte
     {
         FDL_SpotBatman = 0,
         FDL_HearBatman = 1,
@@ -2414,7 +2414,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: FreezeSounds
     /// </summary>
-    public enum FreezeSounds
+    public enum FreezeSounds : byte
     {
         FS_RepelWarning = 0,
         FS_RepelActivated = 1,
@@ -2428,7 +2428,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: FreezeLampState
     /// </summary>
-    public enum FreezeLampState
+    public enum FreezeLampState : byte
     {
         FLS_INITIAL = 0,
         FLS_OFF = 1,
@@ -2441,7 +2441,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: MagneticBlastPhase
     /// </summary>
-    public enum MagneticBlastPhase
+    public enum MagneticBlastPhase : byte
     {
         MBP_STRUGGLE = 0,
         MBP_FLY_BACKWARDS = 1,
@@ -2452,7 +2452,7 @@ public partial class RPawnVillainFreeze : BmSDK.BmGame.RPawnVillainFreezeBase, B
     /// <summary>
     /// Enum: SourceDirection
     /// </summary>
-    public enum SourceDirection
+    public enum SourceDirection : byte
     {
         SD_Front = 0,
         SD_Right = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_AutoInitialiseHelicopters.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_AutoInitialiseHelicopters.g.cs
@@ -116,7 +116,7 @@ public partial class RSeqAct_AutoInitialiseHelicopters : BmSDK.Engine.SequenceAc
     /// <summary>
     /// Enum: HelicopterModes
     /// </summary>
-    public enum HelicopterModes
+    public enum HelicopterModes : byte
     {
         HM_STANDARD = 0,
         HM_CONTROL_NOT_FOUND = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_HelpTextDLC.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_HelpTextDLC.g.cs
@@ -158,7 +158,7 @@ public partial class RSeqAct_HelpTextDLC : BmSDK.BmGame.RSeqAct_HelpText, BmSDK.
     /// <summary>
     /// Enum: EGameActionDLC
     /// </summary>
-    public enum EGameActionDLC
+    public enum EGameActionDLC : byte
     {
         GA_DLC_Ready_Shield = 0,
         GA_DLC_ZipKick_Thug = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_InformantManager.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_InformantManager.g.cs
@@ -484,7 +484,7 @@ public partial class RSeqAct_InformantManager : BmSDK.Engine.SeqAct_Latent, BmSD
     /// <summary>
     /// Enum: eInformantZone
     /// </summary>
-    public enum eInformantZone
+    public enum eInformantZone : byte
     {
         eInformantZone_OW_A = 0,
         eInformantZone_OW_C = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_MadHatterCombat.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_MadHatterCombat.g.cs
@@ -430,7 +430,7 @@ public partial class RSeqAct_MadHatterCombat : BmSDK.Engine.SeqAct_Latent, BmSDK
     /// <summary>
     /// Enum: EHatterFX
     /// </summary>
-    public enum EHatterFX
+    public enum EHatterFX : byte
     {
         EHFX_Karma = 0,
         EHFX_fallingLines = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_NinjaGroupSpawner.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_NinjaGroupSpawner.g.cs
@@ -236,7 +236,7 @@ public partial class RSeqAct_NinjaGroupSpawner : BmSDK.BmGame.RSeqAct_CombatSpaw
     /// <summary>
     /// Enum: SpawnAnimTypes
     /// </summary>
-    public enum SpawnAnimTypes
+    public enum SpawnAnimTypes : byte
     {
         SAT_JumpLeft = 0,
         SAT_JumpRight = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_OpenBackScreen.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_OpenBackScreen.g.cs
@@ -202,7 +202,7 @@ public partial class RSeqAct_OpenBackScreen : BmSDK.Engine.SequenceAction, BmSDK
     /// <summary>
     /// Enum: EBioPageType
     /// </summary>
-    public enum EBioPageType
+    public enum EBioPageType : byte
     {
         BioPage_Info = 0,
         BioPage_Bio = 1,
@@ -214,7 +214,7 @@ public partial class RSeqAct_OpenBackScreen : BmSDK.Engine.SequenceAction, BmSDK
     /// <summary>
     /// Enum: EMapParamType
     /// </summary>
-    public enum EMapParamType
+    public enum EMapParamType : byte
     {
         EMPT_None = 0,
         EMPT_Script = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_PredatorSwingTutorial.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_PredatorSwingTutorial.g.cs
@@ -159,7 +159,7 @@ public partial class RSeqAct_PredatorSwingTutorial : BmSDK.BmGame.RSeqAct_HelpTe
     /// <summary>
     /// Enum: PredSwingTutorialState
     /// </summary>
-    public enum PredSwingTutorialState
+    public enum PredSwingTutorialState : byte
     {
         PSTS_GrappleToVantagePoint = 0,
         PSTS_WaitingForDetectiveModePrompt = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_PushYourLuckCombatSpawner.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_PushYourLuckCombatSpawner.g.cs
@@ -641,7 +641,7 @@ public partial class RSeqAct_PushYourLuckCombatSpawner : BmSDK.BmGame.RSeqAct_He
     /// <summary>
     /// Enum: MySpawnTypes
     /// </summary>
-    public enum MySpawnTypes
+    public enum MySpawnTypes : byte
     {
         MST_Thug = 0,
         MST_ThugArmoured = 1,
@@ -661,7 +661,7 @@ public partial class RSeqAct_PushYourLuckCombatSpawner : BmSDK.BmGame.RSeqAct_He
     /// <summary>
     /// Enum: PYL_Output
     /// </summary>
-    public enum PYL_Output
+    public enum PYL_Output : byte
     {
         PYL_GameOver = 0,
         PYL_SpawnGun = 1,
@@ -689,7 +689,7 @@ public partial class RSeqAct_PushYourLuckCombatSpawner : BmSDK.BmGame.RSeqAct_He
     /// <summary>
     /// Enum: PYL_HudSounds
     /// </summary>
-    public enum PYL_HudSounds
+    public enum PYL_HudSounds : byte
     {
         PHS_CounterChange = 0,
         PHS_Bank = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_SetCharacterProgressUI.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_SetCharacterProgressUI.g.cs
@@ -202,7 +202,7 @@ public partial class RSeqAct_SetCharacterProgressUI : BmSDK.Engine.SequenceActio
     /// <summary>
     /// Enum: StoryUI
     /// </summary>
-    public enum StoryUI
+    public enum StoryUI : byte
     {
         SUI_None = 0,
         SUI_Open = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_SetHeartbeatType.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_SetHeartbeatType.g.cs
@@ -103,7 +103,7 @@ public partial class RSeqAct_SetHeartbeatType : BmSDK.Engine.SequenceAction, BmS
     /// <summary>
     /// Enum: EHeartBeatType2
     /// </summary>
-    public enum EHeartBeatType2
+    public enum EHeartBeatType2 : byte
     {
         EHeartBeatType_Fine = 0,
         EHeartBeatType_Nervous = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_SetHelicopterAggression.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_SetHelicopterAggression.g.cs
@@ -103,7 +103,7 @@ public partial class RSeqAct_SetHelicopterAggression : BmSDK.Engine.SequenceActi
     /// <summary>
     /// Enum: AggroModes
     /// </summary>
-    public enum AggroModes
+    public enum AggroModes : byte
     {
         AM_PASSIVE = 0,
         AM_CHAINGUN = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqAct_SoundMeter.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqAct_SoundMeter.g.cs
@@ -334,7 +334,7 @@ public partial class RSeqAct_SoundMeter : BmSDK.Engine.SeqAct_Latent, BmSDK.IGam
     /// <summary>
     /// Enum: SoundMeterVolume
     /// </summary>
-    public enum SoundMeterVolume
+    public enum SoundMeterVolume : byte
     {
         CSMV_Quiet = 0,
         CSMV_Medium = 1,

--- a/src/BmSDK/Generated/BmScript/RSeqEvent_HelicopterDialogueTrigger.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSeqEvent_HelicopterDialogueTrigger.g.cs
@@ -101,7 +101,7 @@ public partial class RSeqEvent_HelicopterDialogueTrigger : BmSDK.Engine.Sequence
     /// <summary>
     /// Enum: HeliDialogue
     /// </summary>
-    public enum HeliDialogue
+    public enum HeliDialogue : byte
     {
         HD_BatmanSeen = 0,
         HD_BatmanCombatSeen = 1,

--- a/src/BmSDK/Generated/BmScript/RSpecialMoveInstance_CwClawClimbEnd.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSpecialMoveInstance_CwClawClimbEnd.g.cs
@@ -156,7 +156,7 @@ public partial class RSpecialMoveInstance_CwClawClimbEnd : BmSDK.BmGame.RSpecial
     /// <summary>
     /// Enum: LaunchLandDir
     /// </summary>
-    public enum LaunchLandDir
+    public enum LaunchLandDir : byte
     {
         LD_Up = 0,
         LD_Left = 1,

--- a/src/BmSDK/Generated/BmScript/RSpecialMoveInstance_CwClawClimbWallLand.g.cs
+++ b/src/BmSDK/Generated/BmScript/RSpecialMoveInstance_CwClawClimbWallLand.g.cs
@@ -342,7 +342,7 @@ public partial class RSpecialMoveInstance_CwClawClimbWallLand : BmSDK.BmGame.RSp
     /// <summary>
     /// Enum: LaunchLandDir
     /// </summary>
-    public enum LaunchLandDir
+    public enum LaunchLandDir : byte
     {
         LD_Up = 0,
         LD_Left = 1,

--- a/src/BmSDK/Generated/Core/DistributionVector.g.cs
+++ b/src/BmSDK/Generated/Core/DistributionVector.g.cs
@@ -112,7 +112,7 @@ public partial class DistributionVector : BmSDK.Component, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDistributionVectorMirrorFlags
     /// </summary>
-    public enum EDistributionVectorMirrorFlags
+    public enum EDistributionVectorMirrorFlags : byte
     {
         EDVMF_Same = 0,
         EDVMF_Different = 1,
@@ -123,7 +123,7 @@ public partial class DistributionVector : BmSDK.Component, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDistributionVectorLockFlags
     /// </summary>
-    public enum EDistributionVectorLockFlags
+    public enum EDistributionVectorLockFlags : byte
     {
         EDVLF_None = 0,
         EDVLF_XY = 1,

--- a/src/BmSDK/Generated/Core/GameObject.g.cs
+++ b/src/BmSDK/Generated/Core/GameObject.g.cs
@@ -3118,7 +3118,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EDebugBreakType
     /// </summary>
-    public enum EDebugBreakType
+    public enum EDebugBreakType : byte
     {
         DEBUGGER_NativeOnly = 0,
         DEBUGGER_ScriptOnly = 1,
@@ -3129,7 +3129,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EAutomatedRunResult
     /// </summary>
-    public enum EAutomatedRunResult
+    public enum EAutomatedRunResult : byte
     {
         ARR_Unknown = 0,
         ARR_OOM = 1,
@@ -3140,7 +3140,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: ETickingGroup
     /// </summary>
-    public enum ETickingGroup
+    public enum ETickingGroup : byte
     {
         TG_PreAsyncWork = 0,
         TG_PreAsyncWork2 = 1,
@@ -4135,7 +4135,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EInterpMethodType
     /// </summary>
-    public enum EInterpMethodType
+    public enum EInterpMethodType : byte
     {
         IMT_UseFixedTangentEvalAndNewAutoTangents = 0,
         IMT_UseFixedTangentEval = 1,
@@ -4146,7 +4146,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EInterpCurveMode
     /// </summary>
-    public enum EInterpCurveMode
+    public enum EInterpCurveMode : byte
     {
         CIM_Linear = 0,
         CIM_CurveAuto = 1,
@@ -4407,7 +4407,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EAspectRatioAxisConstraint
     /// </summary>
-    public enum EAspectRatioAxisConstraint
+    public enum EAspectRatioAxisConstraint : byte
     {
         AspectRatio_MaintainYFOV = 0,
         AspectRatio_MaintainXFOV = 1,
@@ -4418,7 +4418,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EInputEvent
     /// </summary>
-    public enum EInputEvent
+    public enum EInputEvent : byte
     {
         IE_Pressed = 0,
         IE_Released = 1,
@@ -4431,7 +4431,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: EAxis
     /// </summary>
-    public enum EAxis
+    public enum EAxis : byte
     {
         AXIS_NONE = 0,
         AXIS_X = 1,
@@ -4505,7 +4505,7 @@ public partial class GameObject : BmSDK.IGameObject
     /// <summary>
     /// Enum: AlphaBlendType
     /// </summary>
-    public enum AlphaBlendType
+    public enum AlphaBlendType : byte
     {
         ABT_Linear = 0,
         ABT_Cubic = 1,

--- a/src/BmSDK/Generated/Engine/Actor.g.cs
+++ b/src/BmSDK/Generated/Engine/Actor.g.cs
@@ -4489,7 +4489,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDoubleClickDir
     /// </summary>
-    public enum EDoubleClickDir
+    public enum EDoubleClickDir : byte
     {
         DCLICK_None = 0,
         DCLICK_Left = 1,
@@ -4504,7 +4504,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETravelType
     /// </summary>
-    public enum ETravelType
+    public enum ETravelType : byte
     {
         TRAVEL_Absolute = 0,
         TRAVEL_Partial = 1,
@@ -4870,7 +4870,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECollisionType
     /// </summary>
-    public enum ECollisionType
+    public enum ECollisionType : byte
     {
         COLLIDE_CustomDefault = 0,
         COLLIDE_NoCollision = 1,
@@ -5068,7 +5068,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENetRole
     /// </summary>
-    public enum ENetRole
+    public enum ENetRole : byte
     {
         ROLE_None = 0,
         ROLE_SimulatedProxy = 1,
@@ -5150,7 +5150,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMoveDir
     /// </summary>
-    public enum EMoveDir
+    public enum EMoveDir : byte
     {
         MD_Stationary = 0,
         MD_Forward = 1,
@@ -5165,7 +5165,7 @@ public partial class Actor : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPhysics
     /// </summary>
-    public enum EPhysics
+    public enum EPhysics : byte
     {
         PHYS_None = 0,
         PHYS_Walking = 1,

--- a/src/BmSDK/Generated/Engine/AkBank.g.cs
+++ b/src/BmSDK/Generated/Engine/AkBank.g.cs
@@ -307,7 +307,7 @@ public partial class AkBank : BmSDK.Engine.AkAssetBase, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAkBankLoadType
     /// </summary>
-    public enum EAkBankLoadType
+    public enum EAkBankLoadType : byte
     {
         AK_BANK_LOAD_NONE = 0,
         AK_BANK_LOAD_NORMAL = 1,

--- a/src/BmSDK/Generated/Engine/AkComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/AkComponent.g.cs
@@ -1695,7 +1695,7 @@ public partial class AkComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EAkComponentSourceCreateFailReason
     /// </summary>
-    public enum EAkComponentSourceCreateFailReason
+    public enum EAkComponentSourceCreateFailReason : byte
     {
         AK_COMPONENT_SOURCE_CREATE_FAIL_REASON_NONE = 0,
         AK_COMPONENT_SOURCE_CREATE_FAIL_REASON_DISTANT = 1,
@@ -1708,7 +1708,7 @@ public partial class AkComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EAkComponentUpdate
     /// </summary>
-    public enum EAkComponentUpdate
+    public enum EAkComponentUpdate : byte
     {
         AK_COMPONENT_UPDATE_SINGLE_AUTO = 0,
         AK_COMPONENT_UPDATE_SINGLE_NO_AUTO = 1,

--- a/src/BmSDK/Generated/Engine/AkWwise.g.cs
+++ b/src/BmSDK/Generated/Engine/AkWwise.g.cs
@@ -930,7 +930,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAkPhysicsNotifyType
     /// </summary>
-    public enum EAkPhysicsNotifyType
+    public enum EAkPhysicsNotifyType : byte
     {
         AK_PHYS_NOTIFY_IMPACT = 0,
         AK_PHYS_NOTIFY_COLLAPSE = 1,
@@ -996,7 +996,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAkIOStreamPriorities
     /// </summary>
-    public enum EAkIOStreamPriorities
+    public enum EAkIOStreamPriorities : byte
     {
         AKIO_PRIORITY_HIGH = 0,
         AKIO_PRIORITY_ABOVE_NORMAL = 1,
@@ -1009,7 +1009,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDialogueHelperType
     /// </summary>
-    public enum EDialogueHelperType
+    public enum EDialogueHelperType : byte
     {
         DialogueHelper_None = 0,
         DialogueHelper_Player = 1,
@@ -1030,7 +1030,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAkGameSyncType
     /// </summary>
-    public enum EAkGameSyncType
+    public enum EAkGameSyncType : byte
     {
         AK_GS_GENERAL = 0,
         AK_GS_SFX = 1,
@@ -1046,7 +1046,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGlobalAudioSourceID
     /// </summary>
-    public enum EGlobalAudioSourceID
+    public enum EGlobalAudioSourceID : byte
     {
         AK_INVALID_SOURCE_ID = 0,
         AK_RESERVED_SOURCE_ID = 1,
@@ -1064,7 +1064,7 @@ public partial class AkWwise : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EListenerID
     /// </summary>
-    public enum EListenerID
+    public enum EListenerID : byte
     {
         AK_LISTENER_PLAYER = 0,
         AK_LISTENER_CAMERA = 1,

--- a/src/BmSDK/Generated/Engine/AmbientOcclusionEffect.g.cs
+++ b/src/BmSDK/Generated/Engine/AmbientOcclusionEffect.g.cs
@@ -81,7 +81,7 @@ public partial class AmbientOcclusionEffect : BmSDK.Engine.PostProcessEffect, Bm
     /// <summary>
     /// Enum: EAmbientOcclusionQuality
     /// </summary>
-    public enum EAmbientOcclusionQuality
+    public enum EAmbientOcclusionQuality : byte
     {
         AO_High = 0,
         AO_Medium = 1,

--- a/src/BmSDK/Generated/Engine/AnimNode.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimNode.g.cs
@@ -396,7 +396,7 @@ public partial class AnimNode : BmSDK.Engine.AnimObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESliderType
     /// </summary>
-    public enum ESliderType
+    public enum ESliderType : byte
     {
         ST_1D = 0,
         ST_2D = 1,

--- a/src/BmSDK/Generated/Engine/AnimNodeAimOffset.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimNodeAimOffset.g.cs
@@ -354,7 +354,7 @@ public partial class AnimNodeAimOffset : BmSDK.Engine.AnimNodeBlendBase, BmSDK.I
     /// <summary>
     /// Enum: EAimID
     /// </summary>
-    public enum EAimID
+    public enum EAimID : byte
     {
         EAID_LeftUp = 0,
         EAID_LeftDown = 1,
@@ -379,7 +379,7 @@ public partial class AnimNodeAimOffset : BmSDK.Engine.AnimNodeBlendBase, BmSDK.I
     /// <summary>
     /// Enum: EAnimAimDir
     /// </summary>
-    public enum EAnimAimDir
+    public enum EAnimAimDir : byte
     {
         ANIMAIM_LEFTUP = 0,
         ANIMAIM_CENTERUP = 1,

--- a/src/BmSDK/Generated/Engine/AnimNodeBlendByBase.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimNodeBlendByBase.g.cs
@@ -126,7 +126,7 @@ public partial class AnimNodeBlendByBase : BmSDK.Engine.AnimNodeBlendList, BmSDK
     /// <summary>
     /// Enum: EBaseBlendType
     /// </summary>
-    public enum EBaseBlendType
+    public enum EBaseBlendType : byte
     {
         BBT_ByActorTag = 0,
         BBT_ByActorClass = 1,

--- a/src/BmSDK/Generated/Engine/AnimNodeSequence.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimNodeSequence.g.cs
@@ -347,7 +347,7 @@ public partial class AnimNodeSequence : BmSDK.Engine.AnimNode, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERootRotationOption
     /// </summary>
-    public enum ERootRotationOption
+    public enum ERootRotationOption : byte
     {
         RRO_Default = 0,
         RRO_Discard = 1,
@@ -358,7 +358,7 @@ public partial class AnimNodeSequence : BmSDK.Engine.AnimNode, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERootBoneAxis
     /// </summary>
-    public enum ERootBoneAxis
+    public enum ERootBoneAxis : byte
     {
         RBA_Default = 0,
         RBA_Discard = 1,

--- a/src/BmSDK/Generated/Engine/AnimNotify.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimNotify.g.cs
@@ -76,7 +76,7 @@ public partial class AnimNotify : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENotifyCategory
     /// </summary>
-    public enum ENotifyCategory
+    public enum ENotifyCategory : byte
     {
         NOTIFYCATEGORY_Misc = 0,
         NOTIFYCATEGORY_Footsteps = 1,

--- a/src/BmSDK/Generated/Engine/AnimSequence.g.cs
+++ b/src/BmSDK/Generated/Engine/AnimSequence.g.cs
@@ -280,7 +280,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: AnimationKeyFormat
     /// </summary>
-    public enum AnimationKeyFormat
+    public enum AnimationKeyFormat : byte
     {
         AKF_ConstantKeyLerp = 0,
         AKF_VariableKeyLerp = 1,
@@ -395,7 +395,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERootMotionTranslationOption
     /// </summary>
-    public enum ERootMotionTranslationOption
+    public enum ERootMotionTranslationOption : byte
     {
         RMTO_On = 0,
         RMTO_NoExtraction = 1,
@@ -406,7 +406,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERootMotionRotationOption
     /// </summary>
-    public enum ERootMotionRotationOption
+    public enum ERootMotionRotationOption : byte
     {
         RMRO_On = 0,
         RMRO_NoExtraction = 1,
@@ -417,7 +417,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimPhysics
     /// </summary>
-    public enum EAnimPhysics
+    public enum EAnimPhysics : byte
     {
         APHYS_Walking = 0,
         APHYS_Flying = 1,
@@ -516,7 +516,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EForwardYawDirection
     /// </summary>
-    public enum EForwardYawDirection
+    public enum EForwardYawDirection : byte
     {
         FYD_Clockwise = 0,
         FYD_AntiClockwise = 1,
@@ -601,7 +601,7 @@ public partial class AnimSequence : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: AnimationCompressionFormat
     /// </summary>
-    public enum AnimationCompressionFormat
+    public enum AnimationCompressionFormat : byte
     {
         ACF_None = 0,
         ACF_Float96NoW = 1,

--- a/src/BmSDK/Generated/Engine/ApexDestructibleDamageParameters.g.cs
+++ b/src/BmSDK/Generated/Engine/ApexDestructibleDamageParameters.g.cs
@@ -158,7 +158,7 @@ public partial class ApexDestructibleDamageParameters : BmSDK.GameObject, BmSDK.
     /// <summary>
     /// Enum: EDamageParameterOverrideMode
     /// </summary>
-    public enum EDamageParameterOverrideMode
+    public enum EDamageParameterOverrideMode : byte
     {
         DPOM_Absolute = 0,
         DPOM_Multiplier = 1,

--- a/src/BmSDK/Generated/Engine/AudioDevice.g.cs
+++ b/src/BmSDK/Generated/Engine/AudioDevice.g.cs
@@ -910,7 +910,7 @@ public partial class AudioDevice : BmSDK.Subsystem, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAudioDebugLevels
     /// </summary>
-    public enum EAudioDebugLevels
+    public enum EAudioDebugLevels : byte
     {
         AUDIODEBUG_Off = 0,
         AUDIODEBUG_Normal = 1,
@@ -924,7 +924,7 @@ public partial class AudioDevice : BmSDK.Subsystem, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETTSSpeaker
     /// </summary>
-    public enum ETTSSpeaker
+    public enum ETTSSpeaker : byte
     {
         TTSSPEAKER_Paul = 0,
         TTSSPEAKER_Harry = 1,
@@ -941,7 +941,7 @@ public partial class AudioDevice : BmSDK.Subsystem, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDebugState
     /// </summary>
-    public enum EDebugState
+    public enum EDebugState : byte
     {
         DEBUGSTATE_None = 0,
         DEBUGSTATE_IsolateDryAudio = 1,
@@ -957,7 +957,7 @@ public partial class AudioDevice : BmSDK.Subsystem, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESoundClassName
     /// </summary>
-    public enum ESoundClassName
+    public enum ESoundClassName : byte
     {
         Master = 0,
         ESoundClassName_MAX = 1,

--- a/src/BmSDK/Generated/Engine/Brush.g.cs
+++ b/src/BmSDK/Generated/Engine/Brush.g.cs
@@ -193,7 +193,7 @@ public partial class Brush : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECsgOper
     /// </summary>
-    public enum ECsgOper
+    public enum ECsgOper : byte
     {
         CSG_Active = 0,
         CSG_Add = 1,

--- a/src/BmSDK/Generated/Engine/Camera.g.cs
+++ b/src/BmSDK/Generated/Engine/Camera.g.cs
@@ -520,7 +520,7 @@ public partial class Camera : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECameraAnimPlaySpace
     /// </summary>
-    public enum ECameraAnimPlaySpace
+    public enum ECameraAnimPlaySpace : byte
     {
         CAPS_CameraLocal = 0,
         CAPS_World = 1,
@@ -601,7 +601,7 @@ public partial class Camera : BmSDK.Engine.Actor, BmSDK.IGameObject
     /// <summary>
     /// Enum: EViewTargetBlendFunction
     /// </summary>
-    public enum EViewTargetBlendFunction
+    public enum EViewTargetBlendFunction : byte
     {
         VTBlend_Linear = 0,
         VTBlend_Cubic = 1,

--- a/src/BmSDK/Generated/Engine/CameraShake.g.cs
+++ b/src/BmSDK/Generated/Engine/CameraShake.g.cs
@@ -183,7 +183,7 @@ public partial class CameraShake : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EInitialOscillatorOffset
     /// </summary>
-    public enum EInitialOscillatorOffset
+    public enum EInitialOscillatorOffset : byte
     {
         EOO_OffsetRandom = 0,
         EOO_OffsetZero = 1,

--- a/src/BmSDK/Generated/Engine/CoverLink.g.cs
+++ b/src/BmSDK/Generated/Engine/CoverLink.g.cs
@@ -960,7 +960,7 @@ public partial class CoverLink : BmSDK.Engine.NavigationPoint, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFireLinkID
     /// </summary>
-    public enum EFireLinkID
+    public enum EFireLinkID : byte
     {
         FLI_FireLink = 0,
         FLI_RejectedFireLink = 1,
@@ -970,7 +970,7 @@ public partial class CoverLink : BmSDK.Engine.NavigationPoint, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECoverLocationDescription
     /// </summary>
-    public enum ECoverLocationDescription
+    public enum ECoverLocationDescription : byte
     {
         CoverDesc_None = 0,
         CoverDesc_InWindow = 1,
@@ -990,7 +990,7 @@ public partial class CoverLink : BmSDK.Engine.NavigationPoint, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECoverType
     /// </summary>
-    public enum ECoverType
+    public enum ECoverType : byte
     {
         CT_None = 0,
         CT_Standing = 1,
@@ -1001,7 +1001,7 @@ public partial class CoverLink : BmSDK.Engine.NavigationPoint, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECoverDirection
     /// </summary>
-    public enum ECoverDirection
+    public enum ECoverDirection : byte
     {
         CD_Default = 0,
         CD_Left = 1,
@@ -1013,7 +1013,7 @@ public partial class CoverLink : BmSDK.Engine.NavigationPoint, BmSDK.IGameObject
     /// <summary>
     /// Enum: ECoverAction
     /// </summary>
-    public enum ECoverAction
+    public enum ECoverAction : byte
     {
         CA_Default = 0,
         CA_BlindLeft = 1,

--- a/src/BmSDK/Generated/Engine/DOFEffect.g.cs
+++ b/src/BmSDK/Generated/Engine/DOFEffect.g.cs
@@ -76,7 +76,7 @@ public partial class DOFEffect : BmSDK.Engine.PostProcessEffect, BmSDK.IGameObje
     /// <summary>
     /// Enum: EFocusType
     /// </summary>
-    public enum EFocusType
+    public enum EFocusType : byte
     {
         FOCUS_Distance = 0,
         FOCUS_Position = 1,

--- a/src/BmSDK/Generated/Engine/DecalComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/DecalComponent.g.cs
@@ -136,7 +136,7 @@ public partial class DecalComponent : BmSDK.Engine.PrimitiveComponent, BmSDK.IGa
     /// <summary>
     /// Enum: EFilterMode
     /// </summary>
-    public enum EFilterMode
+    public enum EFilterMode : byte
     {
         FM_None = 0,
         FM_Ignore = 1,
@@ -147,7 +147,7 @@ public partial class DecalComponent : BmSDK.Engine.PrimitiveComponent, BmSDK.IGa
     /// <summary>
     /// Enum: EDecalTransform
     /// </summary>
-    public enum EDecalTransform
+    public enum EDecalTransform : byte
     {
         DecalTransform_OwnerAbsolute = 0,
         DecalTransform_OwnerRelative = 1,

--- a/src/BmSDK/Generated/Engine/DistributionFloatParameterBase.g.cs
+++ b/src/BmSDK/Generated/Engine/DistributionFloatParameterBase.g.cs
@@ -76,7 +76,7 @@ public partial class DistributionFloatParameterBase : BmSDK.Engine.DistributionF
     /// <summary>
     /// Enum: DistributionParamMode
     /// </summary>
-    public enum DistributionParamMode
+    public enum DistributionParamMode : byte
     {
         DPM_Normal = 0,
         DPM_Abs = 1,

--- a/src/BmSDK/Generated/Engine/DynamicLightEnvironmentComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/DynamicLightEnvironmentComponent.g.cs
@@ -117,7 +117,7 @@ public partial class DynamicLightEnvironmentComponent : BmSDK.Engine.LightEnviro
     /// <summary>
     /// Enum: EDynamicLightEnvironmentBoundsMethod
     /// </summary>
-    public enum EDynamicLightEnvironmentBoundsMethod
+    public enum EDynamicLightEnvironmentBoundsMethod : byte
     {
         DLEB_OwnerComponents = 0,
         DLEB_ManualOverride = 1,
@@ -551,7 +551,7 @@ public partial class DynamicLightEnvironmentComponent : BmSDK.Engine.LightEnviro
     /// <summary>
     /// Enum: DLEC_Mode
     /// </summary>
-    public enum DLEC_Mode
+    public enum DLEC_Mode : byte
     {
         DLEC_Unmolested = 0,
         DLEC_APlus3D = 1,

--- a/src/BmSDK/Generated/Engine/EngineTypes.g.cs
+++ b/src/BmSDK/Generated/Engine/EngineTypes.g.cs
@@ -569,7 +569,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELightingBuildQuality
     /// </summary>
-    public enum ELightingBuildQuality
+    public enum ELightingBuildQuality : byte
     {
         Quality_Preview = 0,
         Quality_Medium = 1,
@@ -598,7 +598,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileAmbientOcclusionSource
     /// </summary>
-    public enum EMobileAmbientOcclusionSource
+    public enum EMobileAmbientOcclusionSource : byte
     {
         MAOS_Disabled = 0,
         MAOS_VertexColorRed = 1,
@@ -611,7 +611,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileSpecularMask
     /// </summary>
-    public enum EMobileSpecularMask
+    public enum EMobileSpecularMask : byte
     {
         MSM_Constant = 0,
         MSM_Luminance = 1,
@@ -626,7 +626,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileEnvironmentBlendMode
     /// </summary>
-    public enum EMobileEnvironmentBlendMode
+    public enum EMobileEnvironmentBlendMode : byte
     {
         MEBM_Add = 0,
         MEBM_Lerp = 1,
@@ -636,7 +636,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileEmissiveColorSource
     /// </summary>
-    public enum EMobileEmissiveColorSource
+    public enum EMobileEmissiveColorSource : byte
     {
         MECS_EmissiveTexture = 0,
         MECS_BaseTexture = 1,
@@ -647,7 +647,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileTexCoordsSource
     /// </summary>
-    public enum EMobileTexCoordsSource
+    public enum EMobileTexCoordsSource : byte
     {
         MTCS_TexCoords0 = 0,
         MTCS_TexCoords1 = 1,
@@ -659,7 +659,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileTextureBlendFactorSource
     /// </summary>
-    public enum EMobileTextureBlendFactorSource
+    public enum EMobileTextureBlendFactorSource : byte
     {
         MTBFS_VertexColor = 0,
         MTBFS_MaskTexture = 1,
@@ -669,7 +669,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileValueSource
     /// </summary>
-    public enum EMobileValueSource
+    public enum EMobileValueSource : byte
     {
         MVS_Constant = 0,
         MVS_VertexColorRed = 1,
@@ -691,7 +691,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMobileTextureTransformTarget
     /// </summary>
-    public enum EMobileTextureTransformTarget
+    public enum EMobileTextureTransformTarget : byte
     {
         MTTT_BaseTexture = 0,
         MTTT_DetailTexture = 1,
@@ -701,7 +701,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMaterialTessellationMode
     /// </summary>
-    public enum EMaterialTessellationMode
+    public enum EMaterialTessellationMode : byte
     {
         MTM_NoTessellation = 0,
         MTM_FlatTessellation = 1,
@@ -713,7 +713,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMaterialLightingModel
     /// </summary>
-    public enum EMaterialLightingModel
+    public enum EMaterialLightingModel : byte
     {
         MLM_Phong = 0,
         MLM_NonDirectional = 1,
@@ -727,7 +727,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBlendMode
     /// </summary>
-    public enum EBlendMode
+    public enum EBlendMode : byte
     {
         BLEND_Opaque = 0,
         BLEND_Masked = 1,
@@ -811,7 +811,7 @@ public partial class EngineTypes : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPathFindingError
     /// </summary>
-    public enum EPathFindingError
+    public enum EPathFindingError : byte
     {
         PATHERROR_None = 0,
         PATHERROR_STARTPOLYNOTFOUND = 1,

--- a/src/BmSDK/Generated/Engine/FluidInfluenceComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/FluidInfluenceComponent.g.cs
@@ -315,7 +315,7 @@ public partial class FluidInfluenceComponent : BmSDK.Engine.PrimitiveComponent, 
     /// <summary>
     /// Enum: EInfluenceType
     /// </summary>
-    public enum EInfluenceType
+    public enum EInfluenceType : byte
     {
         Fluid_Flow = 0,
         Fluid_Raindrops = 1,

--- a/src/BmSDK/Generated/Engine/FontImportOptions.g.cs
+++ b/src/BmSDK/Generated/Engine/FontImportOptions.g.cs
@@ -355,7 +355,7 @@ public partial class FontImportOptions : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFontImportCharacterSet
     /// </summary>
-    public enum EFontImportCharacterSet
+    public enum EFontImportCharacterSet : byte
     {
         FontICS_Default = 0,
         FontICS_Ansi = 1,

--- a/src/BmSDK/Generated/Engine/ForceFeedbackWaveform.g.cs
+++ b/src/BmSDK/Generated/Engine/ForceFeedbackWaveform.g.cs
@@ -169,7 +169,7 @@ public partial class ForceFeedbackWaveform : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EWaveformFunction
     /// </summary>
-    public enum EWaveformFunction
+    public enum EWaveformFunction : byte
     {
         WF_Constant = 0,
         WF_LinearIncreasing = 1,

--- a/src/BmSDK/Generated/Engine/FracturedBaseComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/FracturedBaseComponent.g.cs
@@ -205,7 +205,7 @@ public partial class FracturedBaseComponent : BmSDK.Engine.StaticMeshComponent, 
     /// <summary>
     /// Enum: ESimpleCollisionUsageType
     /// </summary>
-    public enum ESimpleCollisionUsageType
+    public enum ESimpleCollisionUsageType : byte
     {
         SCUT_Inherit = 0,
         SCUT_Simple = 1,

--- a/src/BmSDK/Generated/Engine/FracturedStaticMeshActor.g.cs
+++ b/src/BmSDK/Generated/Engine/FracturedStaticMeshActor.g.cs
@@ -740,7 +740,7 @@ public partial class FracturedStaticMeshActor : BmSDK.Engine.Actor, BmSDK.IGameO
     /// <summary>
     /// Enum: EFractureMeshExplosionBlastType
     /// </summary>
-    public enum EFractureMeshExplosionBlastType
+    public enum EFractureMeshExplosionBlastType : byte
     {
         FMEBT_Constant = 0,
         FMEBT_Radial = 1,
@@ -751,7 +751,7 @@ public partial class FracturedStaticMeshActor : BmSDK.Engine.Actor, BmSDK.IGameO
     /// <summary>
     /// Enum: EFractureMeshExplosionType
     /// </summary>
-    public enum EFractureMeshExplosionType
+    public enum EFractureMeshExplosionType : byte
     {
         FMET_SinglePart = 0,
         FMET_PartsInRadius = 1,

--- a/src/BmSDK/Generated/Engine/GameEngine.g.cs
+++ b/src/BmSDK/Generated/Engine/GameEngine.g.cs
@@ -259,7 +259,7 @@ public partial class GameEngine : BmSDK.Engine._Engine, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFullyLoadPackageType
     /// </summary>
-    public enum EFullyLoadPackageType
+    public enum EFullyLoadPackageType : byte
     {
         FULLYLOAD_Map = 0,
         FULLYLOAD_Game_PreLoadClass = 1,

--- a/src/BmSDK/Generated/Engine/GameInfo.g.cs
+++ b/src/BmSDK/Generated/Engine/GameInfo.g.cs
@@ -1708,7 +1708,7 @@ public partial class GameInfo : BmSDK.Engine.Info, BmSDK.IGameObject
     /// <summary>
     /// Enum: EStandbyType
     /// </summary>
-    public enum EStandbyType
+    public enum EStandbyType : byte
     {
         STDBY_Rx = 0,
         STDBY_Tx = 1,

--- a/src/BmSDK/Generated/Engine/GameStateObject.g.cs
+++ b/src/BmSDK/Generated/Engine/GameStateObject.g.cs
@@ -242,7 +242,7 @@ public partial class GameStateObject : BmSDK.Engine.GameplayEventsHandler, BmSDK
     /// <summary>
     /// Enum: GameSessionType
     /// </summary>
-    public enum GameSessionType
+    public enum GameSessionType : byte
     {
         GT_SessionInvalid = 0,
         GT_SinglePlayer = 1,

--- a/src/BmSDK/Generated/Engine/GameViewportClient.g.cs
+++ b/src/BmSDK/Generated/Engine/GameViewportClient.g.cs
@@ -767,7 +767,7 @@ public partial class GameViewportClient : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESafeZoneType
     /// </summary>
-    public enum ESafeZoneType
+    public enum ESafeZoneType : byte
     {
         eSZ_TOP = 0,
         eSZ_BOTTOM = 1,
@@ -779,7 +779,7 @@ public partial class GameViewportClient : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESplitScreenType
     /// </summary>
-    public enum ESplitScreenType
+    public enum ESplitScreenType : byte
     {
         eSST_NONE = 0,
         eSST_2P_HORIZONTAL = 1,

--- a/src/BmSDK/Generated/Engine/GameplayEvents.g.cs
+++ b/src/BmSDK/Generated/Engine/GameplayEvents.g.cs
@@ -626,7 +626,7 @@ public partial class GameplayEvents : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EGameStatGroups
     /// </summary>
-    public enum EGameStatGroups
+    public enum EGameStatGroups : byte
     {
         GSG_EngineStats = 0,
         GSG_Game = 1,

--- a/src/BmSDK/Generated/Engine/Interface_NavMeshPathObstacle.g.cs
+++ b/src/BmSDK/Generated/Engine/Interface_NavMeshPathObstacle.g.cs
@@ -13,7 +13,7 @@ public partial interface Interface_NavMeshPathObstacle : BmSDK.Interface
     /// <summary>
     /// Enum: EEdgeHandlingStatus
     /// </summary>
-    public enum EEdgeHandlingStatus
+    public enum EEdgeHandlingStatus : byte
     {
         EHS_AddedBothDirs = 0,
         EHS_Added0to1 = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrack.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrack.g.cs
@@ -76,7 +76,7 @@ public partial class InterpTrack : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETrackActiveCondition
     /// </summary>
-    public enum ETrackActiveCondition
+    public enum ETrackActiveCondition : byte
     {
         ETAC_Always = 0,
         ETAC_GoreEnabled = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrackHeadTracking.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrackHeadTracking.g.cs
@@ -196,7 +196,7 @@ public partial class InterpTrackHeadTracking : BmSDK.Engine.InterpTrack, BmSDK.I
     /// <summary>
     /// Enum: EHeadTrackingAction
     /// </summary>
-    public enum EHeadTrackingAction
+    public enum EHeadTrackingAction : byte
     {
         EHTA_DisableHeadTracking = 0,
         EHTA_EnableHeadTracking = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrackMove.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrackMove.g.cs
@@ -490,7 +490,7 @@ public partial class InterpTrackMove : BmSDK.Engine.InterpTrack, BmSDK.IGameObje
     /// <summary>
     /// Enum: EInterpTrackMoveRotMode
     /// </summary>
-    public enum EInterpTrackMoveRotMode
+    public enum EInterpTrackMoveRotMode : byte
     {
         IMR_Keyframed = 0,
         IMR_LookAtGroup = 1,
@@ -501,7 +501,7 @@ public partial class InterpTrackMove : BmSDK.Engine.InterpTrack, BmSDK.IGameObje
     /// <summary>
     /// Enum: EInterpTrackMoveFrame
     /// </summary>
-    public enum EInterpTrackMoveFrame
+    public enum EInterpTrackMoveFrame : byte
     {
         IMF_World = 0,
         IMF_RelativeToInitial = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrackMoveAxis.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrackMoveAxis.g.cs
@@ -96,7 +96,7 @@ public partial class InterpTrackMoveAxis : BmSDK.Engine.InterpTrackFloatBase, Bm
     /// <summary>
     /// Enum: EInterpMoveAxis
     /// </summary>
-    public enum EInterpMoveAxis
+    public enum EInterpMoveAxis : byte
     {
         AXIS_TranslationX = 0,
         AXIS_TranslationY = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrackToggle.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrackToggle.g.cs
@@ -160,7 +160,7 @@ public partial class InterpTrackToggle : BmSDK.Engine.InterpTrack, BmSDK.IGameOb
     /// <summary>
     /// Enum: ETrackToggleAction
     /// </summary>
-    public enum ETrackToggleAction
+    public enum ETrackToggleAction : byte
     {
         ETTA_Off = 0,
         ETTA_On = 1,

--- a/src/BmSDK/Generated/Engine/InterpTrackVisibility.g.cs
+++ b/src/BmSDK/Generated/Engine/InterpTrackVisibility.g.cs
@@ -151,7 +151,7 @@ public partial class InterpTrackVisibility : BmSDK.Engine.InterpTrack, BmSDK.IGa
     /// <summary>
     /// Enum: EVisibilityTrackCondition
     /// </summary>
-    public enum EVisibilityTrackCondition
+    public enum EVisibilityTrackCondition : byte
     {
         EVTC_Always = 0,
         EVTC_GoreEnabled = 1,
@@ -162,7 +162,7 @@ public partial class InterpTrackVisibility : BmSDK.Engine.InterpTrack, BmSDK.IGa
     /// <summary>
     /// Enum: EVisibilityTrackAction
     /// </summary>
-    public enum EVisibilityTrackAction
+    public enum EVisibilityTrackAction : byte
     {
         EVTA_Hide = 0,
         EVTA_Show = 1,

--- a/src/BmSDK/Generated/Engine/K2Connector.g.cs
+++ b/src/BmSDK/Generated/Engine/K2Connector.g.cs
@@ -108,7 +108,7 @@ public partial class K2Connector : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EK2ConnectorDirection
     /// </summary>
-    public enum EK2ConnectorDirection
+    public enum EK2ConnectorDirection : byte
     {
         K2CD_Input = 0,
         K2CD_Output = 1,
@@ -118,7 +118,7 @@ public partial class K2Connector : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EK2ConnectorType
     /// </summary>
-    public enum EK2ConnectorType
+    public enum EK2ConnectorType : byte
     {
         K2CT_Bool = 0,
         K2CT_Int = 1,

--- a/src/BmSDK/Generated/Engine/LandscapeComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/LandscapeComponent.g.cs
@@ -81,7 +81,7 @@ public partial class LandscapeComponent : BmSDK.Engine.PrimitiveComponent, BmSDK
     /// <summary>
     /// Enum: ETerrainComponentNeighbors
     /// </summary>
-    public enum ETerrainComponentNeighbors
+    public enum ETerrainComponentNeighbors : byte
     {
         TCN_NW = 0,
         TCN_N = 1,

--- a/src/BmSDK/Generated/Engine/LevelGridVolume.g.cs
+++ b/src/BmSDK/Generated/Engine/LevelGridVolume.g.cs
@@ -148,7 +148,7 @@ public partial class LevelGridVolume : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: LevelGridCellShape
     /// </summary>
-    public enum LevelGridCellShape
+    public enum LevelGridCellShape : byte
     {
         LGCS_Box = 0,
         LGCS_Hex = 1,

--- a/src/BmSDK/Generated/Engine/LevelStreaming.g.cs
+++ b/src/BmSDK/Generated/Engine/LevelStreaming.g.cs
@@ -76,7 +76,7 @@ public partial class LevelStreaming : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENavMeshGroup
     /// </summary>
-    public enum ENavMeshGroup
+    public enum ENavMeshGroup : byte
     {
         NavMeshGroup_All = 0,
         NavMeshGroup = 1,
@@ -119,7 +119,7 @@ public partial class LevelStreaming : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELightingGroup
     /// </summary>
-    public enum ELightingGroup
+    public enum ELightingGroup : byte
     {
         LightingGroup_All = 0,
         LightingGroup = 1,

--- a/src/BmSDK/Generated/Engine/LevelStreamingVolume.g.cs
+++ b/src/BmSDK/Generated/Engine/LevelStreamingVolume.g.cs
@@ -93,7 +93,7 @@ public partial class LevelStreamingVolume : BmSDK.Engine.Volume, BmSDK.IGameObje
     /// <summary>
     /// Enum: EStreamingVolumeUsage
     /// </summary>
-    public enum EStreamingVolumeUsage
+    public enum EStreamingVolumeUsage : byte
     {
         SVB_Loading = 0,
         SVB_LoadingAndVisibility = 1,

--- a/src/BmSDK/Generated/Engine/LightComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/LightComponent.g.cs
@@ -243,7 +243,7 @@ public partial class LightComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: EShadowFilterQuality
     /// </summary>
-    public enum EShadowFilterQuality
+    public enum EShadowFilterQuality : byte
     {
         SFQ_Low = 0,
         SFQ_Medium = 1,
@@ -254,7 +254,7 @@ public partial class LightComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: EShadowProjectionTechnique
     /// </summary>
-    public enum EShadowProjectionTechnique
+    public enum EShadowProjectionTechnique : byte
     {
         ShadowProjTech_Default = 0,
         ShadowProjTech_PCF = 1,
@@ -268,7 +268,7 @@ public partial class LightComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: ELightShadowMode
     /// </summary>
-    public enum ELightShadowMode
+    public enum ELightShadowMode : byte
     {
         LightShadow_Normal = 0,
         LightShadow_Modulate = 1,
@@ -279,7 +279,7 @@ public partial class LightComponent : BmSDK.Engine.ActorComponent, BmSDK.IGameOb
     /// <summary>
     /// Enum: ELightAffectsClassification
     /// </summary>
-    public enum ELightAffectsClassification
+    public enum ELightAffectsClassification : byte
     {
         LAC_USER_SELECTED = 0,
         LAC_DYNAMIC_AFFECTING = 1,

--- a/src/BmSDK/Generated/Engine/Material.g.cs
+++ b/src/BmSDK/Generated/Engine/Material.g.cs
@@ -81,7 +81,7 @@ public partial class Material : BmSDK.Engine.MaterialInterface, BmSDK.IGameObjec
     /// <summary>
     /// Enum: MatLoadedPhysMaterial
     /// </summary>
-    public enum MatLoadedPhysMaterial
+    public enum MatLoadedPhysMaterial : byte
     {
         LPM_NoLoadedPhysMat = 0,
         LPM_MAX = 1,
@@ -90,7 +90,7 @@ public partial class Material : BmSDK.Engine.MaterialInterface, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EParticleDownsampling
     /// </summary>
-    public enum EParticleDownsampling
+    public enum EParticleDownsampling : byte
     {
         PDS_Full = 0,
         PDS_Half = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionAntialiasedTextureMask.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionAntialiasedTextureMask.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionAntialiasedTextureMask : BmSDK.Engine.Mat
     /// <summary>
     /// Enum: ETextureColorChannel
     /// </summary>
-    public enum ETextureColorChannel
+    public enum ETextureColorChannel : byte
     {
         TCC_Red = 0,
         TCC_Green = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionBlendMode.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionBlendMode.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionBlendMode : BmSDK.Engine.MaterialExpressi
     /// <summary>
     /// Enum: EBlendModeFilter
     /// </summary>
-    public enum EBlendModeFilter
+    public enum EBlendModeFilter : byte
     {
         BlendMode_Normal = 0,
         BlendMode_Darken = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionBlurSceneTexture.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionBlurSceneTexture.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionBlurSceneTexture : BmSDK.Engine.MaterialE
     /// <summary>
     /// Enum: ESampleBlurSceneType
     /// </summary>
-    public enum ESampleBlurSceneType
+    public enum ESampleBlurSceneType : byte
     {
         SampleBlurScene_PoissonDisc = 0,
         SampleBlurScene_MAX = 1,
@@ -90,7 +90,7 @@ public partial class MaterialExpressionBlurSceneTexture : BmSDK.Engine.MaterialE
     /// <summary>
     /// Enum: EBlurSceneTextureType
     /// </summary>
-    public enum EBlurSceneTextureType
+    public enum EBlurSceneTextureType : byte
     {
         BlurSceneTex_Lighting = 0,
         BlurSceneTex_MAX = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionBlurTextureSample.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionBlurTextureSample.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionBlurTextureSample : BmSDK.Engine.Material
     /// <summary>
     /// Enum: ESampleBlurType
     /// </summary>
-    public enum ESampleBlurType
+    public enum ESampleBlurType : byte
     {
         SampleBlur_PoissonDisc = 0,
         SampleBlur_Mip = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionContractExpand.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionContractExpand.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionContractExpand : BmSDK.Engine.MaterialExp
     /// <summary>
     /// Enum: EContractOrExpandInput
     /// </summary>
-    public enum EContractOrExpandInput
+    public enum EContractOrExpandInput : byte
     {
         Contract_Input = 0,
         Expand_Input = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionCustom.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionCustom.g.cs
@@ -142,7 +142,7 @@ public partial class MaterialExpressionCustom : BmSDK.Engine.MaterialExpression,
     /// <summary>
     /// Enum: ECustomMaterialOutputType
     /// </summary>
-    public enum ECustomMaterialOutputType
+    public enum ECustomMaterialOutputType : byte
     {
         CMOT_Float1 = 0,
         CMOT_Float2 = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionDecodeMask.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionDecodeMask.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionDecodeMask : BmSDK.Engine.MaterialExpress
     /// <summary>
     /// Enum: EDecodeBlendType
     /// </summary>
-    public enum EDecodeBlendType
+    public enum EDecodeBlendType : byte
     {
         DECODE_Replace = 0,
         DECODE_Add = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionSceneTexture.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionSceneTexture.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionSceneTexture : BmSDK.Engine.MaterialExpre
     /// <summary>
     /// Enum: ESceneTextureType
     /// </summary>
-    public enum ESceneTextureType
+    public enum ESceneTextureType : byte
     {
         SceneTex_Lighting = 0,
         SceneTex_MAX = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionSphericalMapping.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionSphericalMapping.g.cs
@@ -90,7 +90,7 @@ public partial class MaterialExpressionSphericalMapping : BmSDK.Engine.MaterialE
     /// <summary>
     /// Enum: ESphericalMappingType
     /// </summary>
-    public enum ESphericalMappingType
+    public enum ESphericalMappingType : byte
     {
         SPHERICALMAPPING_Correct = 0,
         SPHERICALMAPPING_CheapAlternative = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionTerrainLayerCoords.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionTerrainLayerCoords.g.cs
@@ -126,7 +126,7 @@ public partial class MaterialExpressionTerrainLayerCoords : BmSDK.Engine.Materia
     /// <summary>
     /// Enum: ETerrainCoordMappingType
     /// </summary>
-    public enum ETerrainCoordMappingType
+    public enum ETerrainCoordMappingType : byte
     {
         TCMT_Auto = 0,
         TCMT_XY = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionTransform.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionTransform.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionTransform : BmSDK.Engine.MaterialExpressi
     /// <summary>
     /// Enum: EMaterialVectorCoordTransform
     /// </summary>
-    public enum EMaterialVectorCoordTransform
+    public enum EMaterialVectorCoordTransform : byte
     {
         TRANSFORM_World = 0,
         TRANSFORM_View = 1,
@@ -93,7 +93,7 @@ public partial class MaterialExpressionTransform : BmSDK.Engine.MaterialExpressi
     /// <summary>
     /// Enum: EMaterialVectorCoordTransformSource
     /// </summary>
-    public enum EMaterialVectorCoordTransformSource
+    public enum EMaterialVectorCoordTransformSource : byte
     {
         TRANSFORMSOURCE_World = 0,
         TRANSFORMSOURCE_Local = 1,

--- a/src/BmSDK/Generated/Engine/MaterialExpressionTransformPosition.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialExpressionTransformPosition.g.cs
@@ -81,7 +81,7 @@ public partial class MaterialExpressionTransformPosition : BmSDK.Engine.Material
     /// <summary>
     /// Enum: EMaterialPositionTransform
     /// </summary>
-    public enum EMaterialPositionTransform
+    public enum EMaterialPositionTransform : byte
     {
         TRANSFORMPOS_World = 0,
         TRANSFORMPOS_MAX = 1,

--- a/src/BmSDK/Generated/Engine/MaterialInterface.g.cs
+++ b/src/BmSDK/Generated/Engine/MaterialInterface.g.cs
@@ -472,7 +472,7 @@ public partial class MaterialInterface : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMaterialUsage
     /// </summary>
-    public enum EMaterialUsage
+    public enum EMaterialUsage : byte
     {
         MATUSAGE_SkeletalMesh = 0,
         MATUSAGE_FracturedMeshes = 1,

--- a/src/BmSDK/Generated/Engine/NxForceFieldGeneric.g.cs
+++ b/src/BmSDK/Generated/Engine/NxForceFieldGeneric.g.cs
@@ -99,7 +99,7 @@ public partial class NxForceFieldGeneric : BmSDK.Engine.NxForceField, BmSDK.IGam
     /// <summary>
     /// Enum: FFG_ForceFieldCoordinates
     /// </summary>
-    public enum FFG_ForceFieldCoordinates
+    public enum FFG_ForceFieldCoordinates : byte
     {
         FFG_CARTESIAN = 0,
         FFG_SPHERICAL = 1,

--- a/src/BmSDK/Generated/Engine/NxGenericForceFieldBrush.g.cs
+++ b/src/BmSDK/Generated/Engine/NxGenericForceFieldBrush.g.cs
@@ -263,7 +263,7 @@ public partial class NxGenericForceFieldBrush : BmSDK.Engine.Volume, BmSDK.IGame
     /// <summary>
     /// Enum: FFB_ForceFieldCoordinates
     /// </summary>
-    public enum FFB_ForceFieldCoordinates
+    public enum FFB_ForceFieldCoordinates : byte
     {
         FFB_CARTESIAN = 0,
         FFB_SPHERICAL = 1,

--- a/src/BmSDK/Generated/Engine/OnlineGameSearch.g.cs
+++ b/src/BmSDK/Generated/Engine/OnlineGameSearch.g.cs
@@ -183,7 +183,7 @@ public partial class OnlineGameSearch : BmSDK.Engine.Settings, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineGameSearchSortType
     /// </summary>
-    public enum EOnlineGameSearchSortType
+    public enum EOnlineGameSearchSortType : byte
     {
         OGSSO_Ascending = 0,
         OGSSO_Descending = 1,
@@ -236,7 +236,7 @@ public partial class OnlineGameSearch : BmSDK.Engine.Settings, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineGameSearchComparisonType
     /// </summary>
-    public enum EOnlineGameSearchComparisonType
+    public enum EOnlineGameSearchComparisonType : byte
     {
         OGSCT_Equals = 0,
         OGSCT_NotEquals = 1,
@@ -250,7 +250,7 @@ public partial class OnlineGameSearch : BmSDK.Engine.Settings, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineGameSearchEntryType
     /// </summary>
-    public enum EOnlineGameSearchEntryType
+    public enum EOnlineGameSearchEntryType : byte
     {
         OGSET_Property = 0,
         OGSET_LocalizedSetting = 1,

--- a/src/BmSDK/Generated/Engine/OnlinePlayerStorage.g.cs
+++ b/src/BmSDK/Generated/Engine/OnlinePlayerStorage.g.cs
@@ -709,7 +709,7 @@ public partial class OnlinePlayerStorage : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlinePlayerStorageAsyncState
     /// </summary>
-    public enum EOnlinePlayerStorageAsyncState
+    public enum EOnlinePlayerStorageAsyncState : byte
     {
         OPAS_None = 0,
         OPAS_Read = 1,
@@ -799,7 +799,7 @@ public partial class OnlinePlayerStorage : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineProfilePropertyOwner
     /// </summary>
-    public enum EOnlineProfilePropertyOwner
+    public enum EOnlineProfilePropertyOwner : byte
     {
         OPPO_None = 0,
         OPPO_OnlineService = 1,

--- a/src/BmSDK/Generated/Engine/OnlineProfileSettings.g.cs
+++ b/src/BmSDK/Generated/Engine/OnlineProfileSettings.g.cs
@@ -178,7 +178,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileVoiceThruSpeakersOptions
     /// </summary>
-    public enum EProfileVoiceThruSpeakersOptions
+    public enum EProfileVoiceThruSpeakersOptions : byte
     {
         PVTSO_Off = 0,
         PVTSO_On = 1,
@@ -189,7 +189,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileControllerVibrationToggleOptions
     /// </summary>
-    public enum EProfileControllerVibrationToggleOptions
+    public enum EProfileControllerVibrationToggleOptions : byte
     {
         PCVTO_Off = 0,
         PCVTO_IgnoreThis = 1,
@@ -201,7 +201,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileOmniDirEvadeOptions
     /// </summary>
-    public enum EProfileOmniDirEvadeOptions
+    public enum EProfileOmniDirEvadeOptions : byte
     {
         PODI_Off = 0,
         PODI_On = 1,
@@ -211,7 +211,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileXInversionOptions
     /// </summary>
-    public enum EProfileXInversionOptions
+    public enum EProfileXInversionOptions : byte
     {
         PXIO_Off = 0,
         PXIO_On = 1,
@@ -221,7 +221,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileYInversionOptions
     /// </summary>
-    public enum EProfileYInversionOptions
+    public enum EProfileYInversionOptions : byte
     {
         PYIO_Off = 0,
         PYIO_On = 1,
@@ -231,7 +231,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileRaceAcceleratorControlOptions
     /// </summary>
-    public enum EProfileRaceAcceleratorControlOptions
+    public enum EProfileRaceAcceleratorControlOptions : byte
     {
         PRACO_Trigger = 0,
         PRACO_Button = 1,
@@ -241,7 +241,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileRaceBrakeControlOptions
     /// </summary>
-    public enum EProfileRaceBrakeControlOptions
+    public enum EProfileRaceBrakeControlOptions : byte
     {
         PRBCO_Trigger = 0,
         PRBCO_Button = 1,
@@ -251,7 +251,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileRaceCameraLocationOptions
     /// </summary>
-    public enum EProfileRaceCameraLocationOptions
+    public enum EProfileRaceCameraLocationOptions : byte
     {
         PRCLO_Behind = 0,
         PRCLO_Front = 1,
@@ -262,7 +262,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileRaceTransmissionOptions
     /// </summary>
-    public enum EProfileRaceTransmissionOptions
+    public enum EProfileRaceTransmissionOptions : byte
     {
         PRTO_Auto = 0,
         PRTO_Manual = 1,
@@ -272,7 +272,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileMovementControlOptions
     /// </summary>
-    public enum EProfileMovementControlOptions
+    public enum EProfileMovementControlOptions : byte
     {
         PMCO_L_Thumbstick = 0,
         PMCO_R_Thumbstick = 1,
@@ -282,7 +282,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileAutoCenterOptions
     /// </summary>
-    public enum EProfileAutoCenterOptions
+    public enum EProfileAutoCenterOptions : byte
     {
         PACO_Off = 0,
         PACO_On = 1,
@@ -292,7 +292,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileAutoAimOptions
     /// </summary>
-    public enum EProfileAutoAimOptions
+    public enum EProfileAutoAimOptions : byte
     {
         PAAO_Off = 0,
         PAAO_On = 1,
@@ -302,7 +302,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfilePreferredColorOptions
     /// </summary>
-    public enum EProfilePreferredColorOptions
+    public enum EProfilePreferredColorOptions : byte
     {
         PPCO_None = 0,
         PPCO_Black = 1,
@@ -322,7 +322,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileControllerSensitivityOptions
     /// </summary>
-    public enum EProfileControllerSensitivityOptions
+    public enum EProfileControllerSensitivityOptions : byte
     {
         PCSO_Medium = 0,
         PCSO_Low = 1,
@@ -333,7 +333,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileDifficultyOptions
     /// </summary>
-    public enum EProfileDifficultyOptions
+    public enum EProfileDifficultyOptions : byte
     {
         PDO_Normal = 0,
         PDO_Easy = 1,
@@ -371,7 +371,7 @@ public partial class OnlineProfileSettings : BmSDK.Engine.OnlinePlayerStorage, B
     /// <summary>
     /// Enum: EProfileSettingID
     /// </summary>
-    public enum EProfileSettingID
+    public enum EProfileSettingID : byte
     {
         PSI_Unknown = 0,
         PSI_ControllerVibration = 1,

--- a/src/BmSDK/Generated/Engine/OnlineSubsystem.g.cs
+++ b/src/BmSDK/Generated/Engine/OnlineSubsystem.g.cs
@@ -524,7 +524,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineNewsType
     /// </summary>
-    public enum EOnlineNewsType
+    public enum EOnlineNewsType : byte
     {
         ONT_Unknown = 0,
         ONT_GameNews = 1,
@@ -1065,7 +1065,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineAccountCreateStatus
     /// </summary>
-    public enum EOnlineAccountCreateStatus
+    public enum EOnlineAccountCreateStatus : byte
     {
         OACS_CreateSuccessful = 0,
         OACS_UnknownError = 1,
@@ -1114,7 +1114,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELanBeaconState
     /// </summary>
-    public enum ELanBeaconState
+    public enum ELanBeaconState : byte
     {
         LANB_NotUsingLanBeacon = 0,
         LANB_Hosting = 1,
@@ -1200,7 +1200,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENATType
     /// </summary>
-    public enum ENATType
+    public enum ENATType : byte
     {
         NAT_Unknown = 0,
         NAT_Open = 1,
@@ -1212,7 +1212,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineServerConnectionStatus
     /// </summary>
-    public enum EOnlineServerConnectionStatus
+    public enum EOnlineServerConnectionStatus : byte
     {
         OSCS_NotConnected = 0,
         OSCS_Connected = 1,
@@ -1335,7 +1335,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineContentType
     /// </summary>
-    public enum EOnlineContentType
+    public enum EOnlineContentType : byte
     {
         OCT_Downloaded = 0,
         OCT_SaveGame = 1,
@@ -1460,7 +1460,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineFriendState
     /// </summary>
-    public enum EOnlineFriendState
+    public enum EOnlineFriendState : byte
     {
         OFS_Offline = 0,
         OFS_Online = 1,
@@ -1472,7 +1472,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineEnumerationReadState
     /// </summary>
-    public enum EOnlineEnumerationReadState
+    public enum EOnlineEnumerationReadState : byte
     {
         OERS_NotStarted = 0,
         OERS_InProgress = 1,
@@ -1484,7 +1484,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineGameState
     /// </summary>
-    public enum EOnlineGameState
+    public enum EOnlineGameState : byte
     {
         OGS_NoSession = 0,
         OGS_Pending = 1,
@@ -1498,7 +1498,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENetworkNotificationPosition
     /// </summary>
-    public enum ENetworkNotificationPosition
+    public enum ENetworkNotificationPosition : byte
     {
         NNP_TopLeft = 0,
         NNP_TopCenter = 1,
@@ -1540,7 +1540,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EFeaturePrivilegeLevel
     /// </summary>
-    public enum EFeaturePrivilegeLevel
+    public enum EFeaturePrivilegeLevel : byte
     {
         FPL_Disabled = 0,
         FPL_EnabledFriendsOnly = 1,
@@ -1551,7 +1551,7 @@ public partial class OnlineSubsystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ELoginStatus
     /// </summary>
-    public enum ELoginStatus
+    public enum ELoginStatus : byte
     {
         LS_NotLoggedIn = 0,
         LS_UsingLocalProfile = 1,

--- a/src/BmSDK/Generated/Engine/ParticleEmitter.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleEmitter.g.cs
@@ -76,7 +76,7 @@ public partial class ParticleEmitter : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EEmitterRenderMode
     /// </summary>
-    public enum EEmitterRenderMode
+    public enum EEmitterRenderMode : byte
     {
         ERM_Normal = 0,
         ERM_Point = 1,
@@ -88,7 +88,7 @@ public partial class ParticleEmitter : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EParticleSubUVInterpMethod
     /// </summary>
-    public enum EParticleSubUVInterpMethod
+    public enum EParticleSubUVInterpMethod : byte
     {
         PSUVIM_None = 0,
         PSUVIM_Linear = 1,
@@ -135,7 +135,7 @@ public partial class ParticleEmitter : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EParticleBurstMethod
     /// </summary>
-    public enum EParticleBurstMethod
+    public enum EParticleBurstMethod : byte
     {
         EPBM_Instant = 0,
         EPBM_Interpolated = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModule.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModule.g.cs
@@ -128,7 +128,7 @@ public partial class ParticleModule : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EParticleSourceSelectionMethod
     /// </summary>
-    public enum EParticleSourceSelectionMethod
+    public enum EParticleSourceSelectionMethod : byte
     {
         EPSSM_Random = 0,
         EPSSM_Sequential = 1,
@@ -138,7 +138,7 @@ public partial class ParticleModule : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EModuleType
     /// </summary>
-    public enum EModuleType
+    public enum EModuleType : byte
     {
         EPMT_General = 0,
         EPMT_TypeData = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleAttractorParticle.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleAttractorParticle.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleAttractorParticle : BmSDK.Engine.ParticleModu
     /// <summary>
     /// Enum: EAttractorParticleSelectionMethod
     /// </summary>
-    public enum EAttractorParticleSelectionMethod
+    public enum EAttractorParticleSelectionMethod : byte
     {
         EAPSM_Random = 0,
         EAPSM_Sequential = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleBeamBase.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleBeamBase.g.cs
@@ -76,7 +76,7 @@ public partial class ParticleModuleBeamBase : BmSDK.Engine.ParticleModule, BmSDK
     /// <summary>
     /// Enum: Beam2SourceTargetTangentMethod
     /// </summary>
-    public enum Beam2SourceTargetTangentMethod
+    public enum Beam2SourceTargetTangentMethod : byte
     {
         PEB2STTM_Direct = 0,
         PEB2STTM_UserSet = 1,
@@ -88,7 +88,7 @@ public partial class ParticleModuleBeamBase : BmSDK.Engine.ParticleModule, BmSDK
     /// <summary>
     /// Enum: Beam2SourceTargetMethod
     /// </summary>
-    public enum Beam2SourceTargetMethod
+    public enum Beam2SourceTargetMethod : byte
     {
         PEB2STM_Default = 0,
         PEB2STM_UserSet = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleBeamModifier.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleBeamModifier.g.cs
@@ -169,7 +169,7 @@ public partial class ParticleModuleBeamModifier : BmSDK.Engine.ParticleModuleBea
     /// <summary>
     /// Enum: BeamModifierType
     /// </summary>
-    public enum BeamModifierType
+    public enum BeamModifierType : byte
     {
         PEB2MT_Source = 0,
         PEB2MT_Target = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleCameraOffset.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleCameraOffset.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleCameraOffset : BmSDK.Engine.ParticleModuleCam
     /// <summary>
     /// Enum: EParticleCameraOffsetUpdateMethod
     /// </summary>
-    public enum EParticleCameraOffsetUpdateMethod
+    public enum EParticleCameraOffsetUpdateMethod : byte
     {
         EPCOUM_DirectSet = 0,
         EPCOUM_Additive = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleCollisionBase.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleCollisionBase.g.cs
@@ -76,7 +76,7 @@ public partial class ParticleModuleCollisionBase : BmSDK.Engine.ParticleModule, 
     /// <summary>
     /// Enum: EParticleCollisionComplete
     /// </summary>
-    public enum EParticleCollisionComplete
+    public enum EParticleCollisionComplete : byte
     {
         EPCC_Kill = 0,
         EPCC_Freeze = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleLocationBoneSocket.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleLocationBoneSocket.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleLocationBoneSocket : BmSDK.Engine.ParticleMod
     /// <summary>
     /// Enum: ELocationBoneSocketSelectionMethod
     /// </summary>
-    public enum ELocationBoneSocketSelectionMethod
+    public enum ELocationBoneSocketSelectionMethod : byte
     {
         BONESOCKETSEL_Sequential = 0,
         BONESOCKETSEL_Random = 1,
@@ -186,7 +186,7 @@ public partial class ParticleModuleLocationBoneSocket : BmSDK.Engine.ParticleMod
     /// <summary>
     /// Enum: ELocationBoneSocketSource
     /// </summary>
-    public enum ELocationBoneSocketSource
+    public enum ELocationBoneSocketSource : byte
     {
         BONESOCKETSOURCE_Bones = 0,
         BONESOCKETSOURCE_Sockets = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleLocationEmitter.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleLocationEmitter.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleLocationEmitter : BmSDK.Engine.ParticleModule
     /// <summary>
     /// Enum: ELocationEmitterSelectionMethod
     /// </summary>
-    public enum ELocationEmitterSelectionMethod
+    public enum ELocationEmitterSelectionMethod : byte
     {
         ELESM_Random = 0,
         ELESM_Sequential = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleLocationPrimitiveCylinder.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleLocationPrimitiveCylinder.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleLocationPrimitiveCylinder : BmSDK.Engine.Part
     /// <summary>
     /// Enum: CylinderHeightAxis
     /// </summary>
-    public enum CylinderHeightAxis
+    public enum CylinderHeightAxis : byte
     {
         PMLPC_HEIGHTAXIS_X = 0,
         PMLPC_HEIGHTAXIS_Y = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleOrbit.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleOrbit.g.cs
@@ -160,7 +160,7 @@ public partial class ParticleModuleOrbit : BmSDK.Engine.ParticleModuleOrbitBase,
     /// <summary>
     /// Enum: EOrbitChainMode
     /// </summary>
-    public enum EOrbitChainMode
+    public enum EOrbitChainMode : byte
     {
         EOChainMode_Add = 0,
         EOChainMode_Scale = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleOrientationAxisLock.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleOrientationAxisLock.g.cs
@@ -90,7 +90,7 @@ public partial class ParticleModuleOrientationAxisLock : BmSDK.Engine.ParticleMo
     /// <summary>
     /// Enum: EParticleAxisLock
     /// </summary>
-    public enum EParticleAxisLock
+    public enum EParticleAxisLock : byte
     {
         EPAL_NONE = 0,
         EPAL_X = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleParameterDynamic.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleParameterDynamic.g.cs
@@ -151,7 +151,7 @@ public partial class ParticleModuleParameterDynamic : BmSDK.Engine.ParticleModul
     /// <summary>
     /// Enum: EEmitterDynamicParameterValue
     /// </summary>
-    public enum EEmitterDynamicParameterValue
+    public enum EEmitterDynamicParameterValue : byte
     {
         EDPV_UserSet = 0,
         EDPV_VelocityX = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleRequired.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleRequired.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleRequired : BmSDK.Engine.ParticleModule, BmSDK
     /// <summary>
     /// Enum: EEmitterNormalsMode
     /// </summary>
-    public enum EEmitterNormalsMode
+    public enum EEmitterNormalsMode : byte
     {
         ENM_CameraFacing = 0,
         ENM_Spherical = 1,
@@ -92,7 +92,7 @@ public partial class ParticleModuleRequired : BmSDK.Engine.ParticleModule, BmSDK
     /// <summary>
     /// Enum: EParticleSortMode
     /// </summary>
-    public enum EParticleSortMode
+    public enum EParticleSortMode : byte
     {
         PSORTMODE_None = 0,
         PSORTMODE_ViewProjDepth = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTrailSource.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTrailSource.g.cs
@@ -150,7 +150,7 @@ public partial class ParticleModuleTrailSource : BmSDK.Engine.ParticleModuleTrai
     /// <summary>
     /// Enum: ETrail2SourceMethod
     /// </summary>
-    public enum ETrail2SourceMethod
+    public enum ETrail2SourceMethod : byte
     {
         PET2SRCM_Default = 0,
         PET2SRCM_Particle = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTrailSpawn.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTrailSpawn.g.cs
@@ -99,7 +99,7 @@ public partial class ParticleModuleTrailSpawn : BmSDK.Engine.ParticleModuleTrail
     /// <summary>
     /// Enum: ETrail2SpawnMethod
     /// </summary>
-    public enum ETrail2SpawnMethod
+    public enum ETrail2SpawnMethod : byte
     {
         PET2SM_Emitter = 0,
         PET2SM_Velocity = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTrailTaper.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTrailTaper.g.cs
@@ -96,7 +96,7 @@ public partial class ParticleModuleTrailTaper : BmSDK.Engine.ParticleModuleTrail
     /// <summary>
     /// Enum: ETrailTaperMethod
     /// </summary>
-    public enum ETrailTaperMethod
+    public enum ETrailTaperMethod : byte
     {
         PETTM_None = 0,
         PETTM_Full = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTypeDataBeam.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTypeDataBeam.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleTypeDataBeam : BmSDK.Engine.ParticleModuleTyp
     /// <summary>
     /// Enum: EBeamEndPointMethod
     /// </summary>
-    public enum EBeamEndPointMethod
+    public enum EBeamEndPointMethod : byte
     {
         PEBEPM_Calculated = 0,
         PEBEPM_Distribution = 1,
@@ -194,7 +194,7 @@ public partial class ParticleModuleTypeDataBeam : BmSDK.Engine.ParticleModuleTyp
     /// <summary>
     /// Enum: EBeamMethod
     /// </summary>
-    public enum EBeamMethod
+    public enum EBeamMethod : byte
     {
         PEBM_Distance = 0,
         PEBM_EndPoints = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTypeDataBeam2.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTypeDataBeam2.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleTypeDataBeam2 : BmSDK.Engine.ParticleModuleTy
     /// <summary>
     /// Enum: EBeamTaperMethod
     /// </summary>
-    public enum EBeamTaperMethod
+    public enum EBeamTaperMethod : byte
     {
         PEBTM_None = 0,
         PEBTM_Full = 1,
@@ -279,7 +279,7 @@ public partial class ParticleModuleTypeDataBeam2 : BmSDK.Engine.ParticleModuleTy
     /// <summary>
     /// Enum: EBeam2Method
     /// </summary>
-    public enum EBeam2Method
+    public enum EBeam2Method : byte
     {
         PEB2M_Distance = 0,
         PEB2M_Target = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTypeDataMesh.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTypeDataMesh.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleTypeDataMesh : BmSDK.Engine.ParticleModuleTyp
     /// <summary>
     /// Enum: EMeshCameraFacingOptions
     /// </summary>
-    public enum EMeshCameraFacingOptions
+    public enum EMeshCameraFacingOptions : byte
     {
         XAxisFacing_NoUp = 0,
         XAxisFacing_ZUp = 1,
@@ -102,7 +102,7 @@ public partial class ParticleModuleTypeDataMesh : BmSDK.Engine.ParticleModuleTyp
     /// <summary>
     /// Enum: EMeshCameraFacingUpAxis
     /// </summary>
-    public enum EMeshCameraFacingUpAxis
+    public enum EMeshCameraFacingUpAxis : byte
     {
         CameraFacing_NoneUP = 0,
         CameraFacing_ZUp = 1,
@@ -115,7 +115,7 @@ public partial class ParticleModuleTypeDataMesh : BmSDK.Engine.ParticleModuleTyp
     /// <summary>
     /// Enum: EMeshScreenAlignment
     /// </summary>
-    public enum EMeshScreenAlignment
+    public enum EMeshScreenAlignment : byte
     {
         PSMA_MeshFaceCameraWithRoll = 0,
         PSMA_MeshFaceCameraWithSpin = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTypeDataMeshPhysX.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTypeDataMeshPhysX.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleTypeDataMeshPhysX : BmSDK.Engine.ParticleModu
     /// <summary>
     /// Enum: EPhysXMeshRotationMethod
     /// </summary>
-    public enum EPhysXMeshRotationMethod
+    public enum EPhysXMeshRotationMethod : byte
     {
         PMRM_Disabled = 0,
         PMRM_Spherical = 1,

--- a/src/BmSDK/Generated/Engine/ParticleModuleTypeDataRibbon.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleModuleTypeDataRibbon.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleModuleTypeDataRibbon : BmSDK.Engine.ParticleModuleT
     /// <summary>
     /// Enum: ETrailsRenderAxisOption
     /// </summary>
-    public enum ETrailsRenderAxisOption
+    public enum ETrailsRenderAxisOption : byte
     {
         Trails_CameraUp = 0,
         Trails_SourceUp = 1,

--- a/src/BmSDK/Generated/Engine/ParticleSpriteEmitter.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleSpriteEmitter.g.cs
@@ -81,7 +81,7 @@ public partial class ParticleSpriteEmitter : BmSDK.Engine.ParticleEmitter, BmSDK
     /// <summary>
     /// Enum: EParticleScreenAlignment
     /// </summary>
-    public enum EParticleScreenAlignment
+    public enum EParticleScreenAlignment : byte
     {
         PSA_Square = 0,
         PSA_Rectangle = 1,

--- a/src/BmSDK/Generated/Engine/ParticleSystem.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleSystem.g.cs
@@ -191,7 +191,7 @@ public partial class ParticleSystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EParticleSystemOcclusionBoundsMethod
     /// </summary>
-    public enum EParticleSystemOcclusionBoundsMethod
+    public enum EParticleSystemOcclusionBoundsMethod : byte
     {
         EPSOBM_None = 0,
         EPSOBM_ParticleBounds = 1,
@@ -218,7 +218,7 @@ public partial class ParticleSystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ParticleSystemLODMethod
     /// </summary>
-    public enum ParticleSystemLODMethod
+    public enum ParticleSystemLODMethod : byte
     {
         PARTICLESYSTEMLODMETHOD_Automatic = 0,
         PARTICLESYSTEMLODMETHOD_DirectSet = 1,
@@ -628,7 +628,7 @@ public partial class ParticleSystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EParticleSystemUpdateMode
     /// </summary>
-    public enum EParticleSystemUpdateMode
+    public enum EParticleSystemUpdateMode : byte
     {
         EPSUM_RealTime = 0,
         EPSUM_FixedTime = 1,

--- a/src/BmSDK/Generated/Engine/ParticleSystemComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/ParticleSystemComponent.g.cs
@@ -1258,7 +1258,7 @@ public partial class ParticleSystemComponent : BmSDK.Engine.PrimitiveComponent, 
     /// <summary>
     /// Enum: EParticleEventType
     /// </summary>
-    public enum EParticleEventType
+    public enum EParticleEventType : byte
     {
         EPET_Any = 0,
         EPET_Spawn = 1,
@@ -1271,7 +1271,7 @@ public partial class ParticleSystemComponent : BmSDK.Engine.PrimitiveComponent, 
     /// <summary>
     /// Enum: ParticleReplayState
     /// </summary>
-    public enum ParticleReplayState
+    public enum ParticleReplayState : byte
     {
         PRS_Disabled = 0,
         PRS_Capturing = 1,
@@ -1379,7 +1379,7 @@ public partial class ParticleSystemComponent : BmSDK.Engine.PrimitiveComponent, 
     /// <summary>
     /// Enum: EParticleSysParamType
     /// </summary>
-    public enum EParticleSysParamType
+    public enum EParticleSysParamType : byte
     {
         PSPT_None = 0,
         PSPT_Scalar = 1,

--- a/src/BmSDK/Generated/Engine/Pawn.g.cs
+++ b/src/BmSDK/Generated/Engine/Pawn.g.cs
@@ -2869,7 +2869,7 @@ public partial class Pawn : BmSDK.Engine.Actor, BmSDK.Engine.Interface_Speaker, 
     /// <summary>
     /// Enum: EPathSearchType
     /// </summary>
-    public enum EPathSearchType
+    public enum EPathSearchType : byte
     {
         PST_Default = 0,
         PST_Breadth = 1,

--- a/src/BmSDK/Generated/Engine/PhysXParticleSystem.g.cs
+++ b/src/BmSDK/Generated/Engine/PhysXParticleSystem.g.cs
@@ -363,7 +363,7 @@ public partial class PhysXParticleSystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPacketSizeMultiplier
     /// </summary>
-    public enum EPacketSizeMultiplier
+    public enum EPacketSizeMultiplier : byte
     {
         EPSM = 0,
         EPSM_2 = 1,
@@ -377,7 +377,7 @@ public partial class PhysXParticleSystem : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESimulationMethod
     /// </summary>
-    public enum ESimulationMethod
+    public enum ESimulationMethod : byte
     {
         ESM_SPH = 0,
         ESM_NO_PARTICLE_INTERACTION = 1,

--- a/src/BmSDK/Generated/Engine/PhysicalMaterial.g.cs
+++ b/src/BmSDK/Generated/Engine/PhysicalMaterial.g.cs
@@ -186,7 +186,7 @@ public partial class PhysicalMaterial : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPhysEffectType
     /// </summary>
-    public enum EPhysEffectType
+    public enum EPhysEffectType : byte
     {
         EPMET_Impact = 0,
         EPMET_Slide = 1,

--- a/src/BmSDK/Generated/Engine/PhysicsAssetInstance.g.cs
+++ b/src/BmSDK/Generated/Engine/PhysicsAssetInstance.g.cs
@@ -601,7 +601,7 @@ public partial class PhysicsAssetInstance : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBoneSpringUsagePriority
     /// </summary>
-    public enum EBoneSpringUsagePriority
+    public enum EBoneSpringUsagePriority : byte
     {
         BONESPRINGUSAGEPRIORITY_None = 0,
         BONESPRINGUSAGEPRIORITY_NetDrive = 1,

--- a/src/BmSDK/Generated/Engine/PlayerController.g.cs
+++ b/src/BmSDK/Generated/Engine/PlayerController.g.cs
@@ -4091,7 +4091,7 @@ public partial class PlayerController : BmSDK.Engine.Controller, BmSDK.IGameObje
     /// <summary>
     /// Enum: EProgressMessageType
     /// </summary>
-    public enum EProgressMessageType
+    public enum EProgressMessageType : byte
     {
         PMT_Clear = 0,
         PMT_Information = 1,
@@ -4335,7 +4335,7 @@ public partial class PlayerController : BmSDK.Engine.Controller, BmSDK.IGameObje
     /// <summary>
     /// Enum: EInputMatchAction
     /// </summary>
-    public enum EInputMatchAction
+    public enum EInputMatchAction : byte
     {
         IMA_GreaterThan = 0,
         IMA_LessThan = 1,
@@ -4345,7 +4345,7 @@ public partial class PlayerController : BmSDK.Engine.Controller, BmSDK.IGameObje
     /// <summary>
     /// Enum: EInputTypes
     /// </summary>
-    public enum EInputTypes
+    public enum EInputTypes : byte
     {
         IT_XAxis = 0,
         IT_YAxis = 1,

--- a/src/BmSDK/Generated/Engine/PrimitiveComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/PrimitiveComponent.g.cs
@@ -1347,7 +1347,7 @@ public partial class PrimitiveComponent : BmSDK.Engine.ActorComponent, BmSDK.IGa
     /// <summary>
     /// Enum: ERadialImpulseFalloff
     /// </summary>
-    public enum ERadialImpulseFalloff
+    public enum ERadialImpulseFalloff : byte
     {
         RIF_Constant = 0,
         RIF_Linear = 1,
@@ -1357,7 +1357,7 @@ public partial class PrimitiveComponent : BmSDK.Engine.ActorComponent, BmSDK.IGa
     /// <summary>
     /// Enum: ERBCollisionChannel
     /// </summary>
-    public enum ERBCollisionChannel
+    public enum ERBCollisionChannel : byte
     {
         RBCC_Default = 0,
         RBCC_Nothing = 1,
@@ -1672,7 +1672,7 @@ public partial class PrimitiveComponent : BmSDK.Engine.ActorComponent, BmSDK.IGa
     /// <summary>
     /// Enum: GJKResult
     /// </summary>
-    public enum GJKResult
+    public enum GJKResult : byte
     {
         GJK_Intersect = 0,
         GJK_NoIntersection = 1,
@@ -1683,7 +1683,7 @@ public partial class PrimitiveComponent : BmSDK.Engine.ActorComponent, BmSDK.IGa
     /// <summary>
     /// Enum: LoadedPhysMaterial
     /// </summary>
-    public enum LoadedPhysMaterial
+    public enum LoadedPhysMaterial : byte
     {
         LPM_NoLoadedPhysMat = 0,
         LPM_MAX = 1,

--- a/src/BmSDK/Generated/Engine/ProcBuilding.g.cs
+++ b/src/BmSDK/Generated/Engine/ProcBuilding.g.cs
@@ -284,7 +284,7 @@ public partial class ProcBuilding : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: EBuildingStatsBrowserColumns
     /// </summary>
-    public enum EBuildingStatsBrowserColumns
+    public enum EBuildingStatsBrowserColumns : byte
     {
         BSBC_Name = 0,
         BSBC_Ruleset = 1,
@@ -709,7 +709,7 @@ public partial class ProcBuilding : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPBCornerType
     /// </summary>
-    public enum EPBCornerType
+    public enum EPBCornerType : byte
     {
         EPBC_Default = 0,
         EPBC_Chamfer = 1,
@@ -790,7 +790,7 @@ public partial class ProcBuilding : BmSDK.Engine.Volume, BmSDK.IGameObject
     /// <summary>
     /// Enum: EScopeEdge
     /// </summary>
-    public enum EScopeEdge
+    public enum EScopeEdge : byte
     {
         EPSA_Top = 0,
         EPSA_Bottom = 1,

--- a/src/BmSDK/Generated/Engine/ProcBuildingRuleset.g.cs
+++ b/src/BmSDK/Generated/Engine/ProcBuildingRuleset.g.cs
@@ -81,7 +81,7 @@ public partial class ProcBuildingRuleset : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EProcBuildingAxis
     /// </summary>
-    public enum EProcBuildingAxis
+    public enum EProcBuildingAxis : byte
     {
         EPBAxis_X = 0,
         EPBAxis_Z = 1,

--- a/src/BmSDK/Generated/Engine/Pylon.g.cs
+++ b/src/BmSDK/Generated/Engine/Pylon.g.cs
@@ -328,7 +328,7 @@ public partial class Pylon : BmSDK.Engine.NavigationPoint, BmSDK.Engine.EditorLi
     /// <summary>
     /// Enum: ENavMeshEdgeType
     /// </summary>
-    public enum ENavMeshEdgeType
+    public enum ENavMeshEdgeType : byte
     {
         NAVEDGE_Normal = 0,
         NAVEDGE_Mantle = 1,

--- a/src/BmSDK/Generated/Engine/RAnimZip_Settings.g.cs
+++ b/src/BmSDK/Generated/Engine/RAnimZip_Settings.g.cs
@@ -465,7 +465,7 @@ public partial class RAnimZip_Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimZipTranslationScaleCodec
     /// </summary>
-    public enum EAnimZipTranslationScaleCodec
+    public enum EAnimZipTranslationScaleCodec : byte
     {
         AZTSC_Float = 0,
         AZTSC_NoScale_Float = 1,
@@ -477,7 +477,7 @@ public partial class RAnimZip_Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimZipRotationCodec
     /// </summary>
-    public enum EAnimZipRotationCodec
+    public enum EAnimZipRotationCodec : byte
     {
         AZRC_QuatMax = 0,
         AZRC_QuatMax_2 = 1,
@@ -492,7 +492,7 @@ public partial class RAnimZip_Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EAnimZipPreset
     /// </summary>
-    public enum EAnimZipPreset
+    public enum EAnimZipPreset : byte
     {
         AZP_Default = 0,
         AZP_Default50 = 1,

--- a/src/BmSDK/Generated/Engine/RB_BodySetup.g.cs
+++ b/src/BmSDK/Generated/Engine/RB_BodySetup.g.cs
@@ -311,7 +311,7 @@ public partial class RB_BodySetup : BmSDK.Engine.KMeshProps, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESleepFamily
     /// </summary>
-    public enum ESleepFamily
+    public enum ESleepFamily : byte
     {
         SF_Normal = 0,
         SF_Sensitive = 1,

--- a/src/BmSDK/Generated/Engine/RB_ConstraintSetup.g.cs
+++ b/src/BmSDK/Generated/Engine/RB_ConstraintSetup.g.cs
@@ -106,7 +106,7 @@ public partial class RB_ConstraintSetup : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ConstraintProjectionMode
     /// </summary>
-    public enum ConstraintProjectionMode
+    public enum ConstraintProjectionMode : byte
     {
         ECPM_Linear = 0,
         ECPM_LinearAndAngular = 1,

--- a/src/BmSDK/Generated/Engine/RB_ForceComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/RB_ForceComponent.g.cs
@@ -222,7 +222,7 @@ public partial class RB_ForceComponent : BmSDK.Engine.PrimitiveComponent, BmSDK.
     /// <summary>
     /// Enum: EForceModeType
     /// </summary>
-    public enum EForceModeType
+    public enum EForceModeType : byte
     {
         FMT_Constant = 0,
         FMT_Impulse = 1,

--- a/src/BmSDK/Generated/Engine/RB_RadialForceActor.g.cs
+++ b/src/BmSDK/Generated/Engine/RB_RadialForceActor.g.cs
@@ -207,7 +207,7 @@ public partial class RB_RadialForceActor : BmSDK.Engine.RigidBodyBase, BmSDK.IGa
     /// <summary>
     /// Enum: ERadialForceType
     /// </summary>
-    public enum ERadialForceType
+    public enum ERadialForceType : byte
     {
         RFT_Force = 0,
         RFT_Impulse = 1,

--- a/src/BmSDK/Generated/Engine/RDialogueEvent.g.cs
+++ b/src/BmSDK/Generated/Engine/RDialogueEvent.g.cs
@@ -428,7 +428,7 @@ public partial class RDialogueEvent : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPlaceHolder
     /// </summary>
-    public enum EPlaceHolder
+    public enum EPlaceHolder : byte
     {
         PH_UNKNOWN = 0,
         PH_PLACEHOLDER = 1,
@@ -445,7 +445,7 @@ public partial class RDialogueEvent : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPriority
     /// </summary>
-    public enum EPriority
+    public enum EPriority : byte
     {
         PRI_UNKNOWN = 0,
         PRI_EMOTE = 1,

--- a/src/BmSDK/Generated/Engine/RFlapsAssetInstance.g.cs
+++ b/src/BmSDK/Generated/Engine/RFlapsAssetInstance.g.cs
@@ -565,7 +565,7 @@ public partial class RFlapsAssetInstance : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERFlapsPoseExtractMode
     /// </summary>
-    public enum ERFlapsPoseExtractMode
+    public enum ERFlapsPoseExtractMode : byte
     {
         RFPEM_Full = 0,
         RFPEM_ConnectedRFlapChainsOnlyOrChildrenOrRFlaps = 1,

--- a/src/BmSDK/Generated/Engine/RFlaps_BodySetup.g.cs
+++ b/src/BmSDK/Generated/Engine/RFlaps_BodySetup.g.cs
@@ -294,7 +294,7 @@ public partial class RFlaps_BodySetup : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ERFlapsPoseControlType
     /// </summary>
-    public enum ERFlapsPoseControlType
+    public enum ERFlapsPoseControlType : byte
     {
         RFPCT_RotationOnly = 0,
         RFPCT_PositionOnly = 1,

--- a/src/BmSDK/Generated/Engine/RFlaps_ConstraintSetup.g.cs
+++ b/src/BmSDK/Generated/Engine/RFlaps_ConstraintSetup.g.cs
@@ -103,7 +103,7 @@ public partial class RFlaps_ConstraintSetup : BmSDK.GameObject, BmSDK.IGameObjec
     /// <summary>
     /// Enum: ERFlapsConstraintType
     /// </summary>
-    public enum ERFlapsConstraintType
+    public enum ERFlapsConstraintType : byte
     {
         RFCT_Anim = 0,
         RFCT_AnimBlend = 1,

--- a/src/BmSDK/Generated/Engine/RLedgeSetup.g.cs
+++ b/src/BmSDK/Generated/Engine/RLedgeSetup.g.cs
@@ -196,7 +196,7 @@ public partial class RLedgeSetup : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ValidUpAxis
     /// </summary>
-    public enum ValidUpAxis
+    public enum ValidUpAxis : byte
     {
         LIA_None = 0,
         LIA_Z_Pos = 1,

--- a/src/BmSDK/Generated/Engine/RPhysicalMaterialTexture.g.cs
+++ b/src/BmSDK/Generated/Engine/RPhysicalMaterialTexture.g.cs
@@ -160,7 +160,7 @@ public partial class RPhysicalMaterialTexture : BmSDK.GameObject, BmSDK.IGameObj
     /// <summary>
     /// Enum: ERPMT_Encoding
     /// </summary>
-    public enum ERPMT_Encoding
+    public enum ERPMT_Encoding : byte
     {
         ERPMT_None = 0,
         ERPMT_0BPP = 1,

--- a/src/BmSDK/Generated/Engine/RSkeletalMeshComponent_Export.g.cs
+++ b/src/BmSDK/Generated/Engine/RSkeletalMeshComponent_Export.g.cs
@@ -189,7 +189,7 @@ public partial class RSkeletalMeshComponent_Export : BmSDK.GameObject, BmSDK.IGa
     /// <summary>
     /// Enum: EStretchPhase
     /// </summary>
-    public enum EStretchPhase
+    public enum EStretchPhase : byte
     {
         STRETCHPHASE_PostAnimBlend = 0,
         STRETCHPHASE_PreRender = 1,
@@ -199,7 +199,7 @@ public partial class RSkeletalMeshComponent_Export : BmSDK.GameObject, BmSDK.IGa
     /// <summary>
     /// Enum: EParentAnimComponentMode
     /// </summary>
-    public enum EParentAnimComponentMode
+    public enum EParentAnimComponentMode : byte
     {
         PACM_Original = 0,
         PACM_Add = 1,
@@ -212,7 +212,7 @@ public partial class RSkeletalMeshComponent_Export : BmSDK.GameObject, BmSDK.IGa
     /// <summary>
     /// Enum: ESkeletalMeshComponentBoundsType
     /// </summary>
-    public enum ESkeletalMeshComponentBoundsType
+    public enum ESkeletalMeshComponentBoundsType : byte
     {
         SMCBT_Automatic = 0,
         SMCBT_Conservative = 1,
@@ -375,7 +375,7 @@ public partial class RSkeletalMeshComponent_Export : BmSDK.GameObject, BmSDK.IGa
     /// <summary>
     /// Enum: EFaceFXRegisterOwner
     /// </summary>
-    public enum EFaceFXRegisterOwner
+    public enum EFaceFXRegisterOwner : byte
     {
         FXREGISTEROWNER_Code = 0,
         FXREGISTEROWNER_CodeBlink = 1,

--- a/src/BmSDK/Generated/Engine/Route.g.cs
+++ b/src/BmSDK/Generated/Engine/Route.g.cs
@@ -124,7 +124,7 @@ public partial class Route : BmSDK.Engine.Info, BmSDK.Engine.EditorLinkSelection
     /// <summary>
     /// Enum: ERouteType
     /// </summary>
-    public enum ERouteType
+    public enum ERouteType : byte
     {
         ERT_Linear = 0,
         ERT_Loop = 1,
@@ -135,7 +135,7 @@ public partial class Route : BmSDK.Engine.Info, BmSDK.Engine.EditorLinkSelection
     /// <summary>
     /// Enum: ERouteDirection
     /// </summary>
-    public enum ERouteDirection
+    public enum ERouteDirection : byte
     {
         ERD_Forward = 0,
         ERD_Reverse = 1,
@@ -145,7 +145,7 @@ public partial class Route : BmSDK.Engine.Info, BmSDK.Engine.EditorLinkSelection
     /// <summary>
     /// Enum: ERouteFillAction
     /// </summary>
-    public enum ERouteFillAction
+    public enum ERouteFillAction : byte
     {
         RFA_Overwrite = 0,
         RFA_Add = 1,

--- a/src/BmSDK/Generated/Engine/Scene.g.cs
+++ b/src/BmSDK/Generated/Engine/Scene.g.cs
@@ -81,7 +81,7 @@ public partial class Scene : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDetailMode
     /// </summary>
-    public enum EDetailMode
+    public enum EDetailMode : byte
     {
         DM_Low = 0,
         DM_Medium = 1,
@@ -92,7 +92,7 @@ public partial class Scene : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESceneDepthPriorityGroup
     /// </summary>
-    public enum ESceneDepthPriorityGroup
+    public enum ESceneDepthPriorityGroup : byte
     {
         SDPG_UnrealEdBackground = 0,
         SDPG_World = 1,

--- a/src/BmSDK/Generated/Engine/SceneCaptureComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/SceneCaptureComponent.g.cs
@@ -114,7 +114,7 @@ public partial class SceneCaptureComponent : BmSDK.Engine.ActorComponent, BmSDK.
     /// <summary>
     /// Enum: ESceneCaptureViewMode
     /// </summary>
-    public enum ESceneCaptureViewMode
+    public enum ESceneCaptureViewMode : byte
     {
         SceneCapView_Lit = 0,
         SceneCapView_Unlit = 1,

--- a/src/BmSDK/Generated/Engine/SeqAct_ActorFactory.g.cs
+++ b/src/BmSDK/Generated/Engine/SeqAct_ActorFactory.g.cs
@@ -218,7 +218,7 @@ public partial class SeqAct_ActorFactory : BmSDK.Engine.SeqAct_Latent, BmSDK.IGa
     /// <summary>
     /// Enum: EPointSelection
     /// </summary>
-    public enum EPointSelection
+    public enum EPointSelection : byte
     {
         PS_Normal = 0,
         PS_Random = 1,

--- a/src/BmSDK/Generated/Engine/SeqAct_ControlMovieTexture.g.cs
+++ b/src/BmSDK/Generated/Engine/SeqAct_ControlMovieTexture.g.cs
@@ -101,7 +101,7 @@ public partial class SeqAct_ControlMovieTexture : BmSDK.Engine.SequenceAction, B
     /// <summary>
     /// Enum: EMovieControlType
     /// </summary>
-    public enum EMovieControlType
+    public enum EMovieControlType : byte
     {
         MCT_Play = 0,
         MCT_Stop = 1,

--- a/src/BmSDK/Generated/Engine/SeqAct_SetMesh.g.cs
+++ b/src/BmSDK/Generated/Engine/SeqAct_SetMesh.g.cs
@@ -126,7 +126,7 @@ public partial class SeqAct_SetMesh : BmSDK.Engine.SequenceAction, BmSDK.IGameOb
     /// <summary>
     /// Enum: EMeshType
     /// </summary>
-    public enum EMeshType
+    public enum EMeshType : byte
     {
         MeshType_StaticMesh = 0,
         MeshType_SkeletalMesh = 1,

--- a/src/BmSDK/Generated/Engine/SeqEvent_ParticleEvent.g.cs
+++ b/src/BmSDK/Generated/Engine/SeqEvent_ParticleEvent.g.cs
@@ -146,7 +146,7 @@ public partial class SeqEvent_ParticleEvent : BmSDK.Engine.SequenceEvent, BmSDK.
     /// <summary>
     /// Enum: EParticleEventOutputType
     /// </summary>
-    public enum EParticleEventOutputType
+    public enum EParticleEventOutputType : byte
     {
         ePARTICLEOUT_Spawn = 0,
         ePARTICLEOUT_Death = 1,

--- a/src/BmSDK/Generated/Engine/Settings.g.cs
+++ b/src/BmSDK/Generated/Engine/Settings.g.cs
@@ -1287,7 +1287,7 @@ public partial class Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPropertyValueMappingType
     /// </summary>
-    public enum EPropertyValueMappingType
+    public enum EPropertyValueMappingType : byte
     {
         PVMT_RawValue = 0,
         PVMT_PredefinedValues = 1,
@@ -1469,7 +1469,7 @@ public partial class Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ESettingsDataType
     /// </summary>
-    public enum ESettingsDataType
+    public enum ESettingsDataType : byte
     {
         SDT_Empty = 0,
         SDT_Int32 = 1,
@@ -1519,7 +1519,7 @@ public partial class Settings : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EOnlineDataAdvertisementType
     /// </summary>
-    public enum EOnlineDataAdvertisementType
+    public enum EOnlineDataAdvertisementType : byte
     {
         ODAT_DontAdvertise = 0,
         ODAT_OnlineService = 1,

--- a/src/BmSDK/Generated/Engine/SkelControlBase.g.cs
+++ b/src/BmSDK/Generated/Engine/SkelControlBase.g.cs
@@ -353,7 +353,7 @@ public partial class SkelControlBase : BmSDK.Engine.AnimObject, BmSDK.IGameObjec
     /// <summary>
     /// Enum: EBoneControlSpace
     /// </summary>
-    public enum EBoneControlSpace
+    public enum EBoneControlSpace : byte
     {
         BCS_WorldSpace = 0,
         BCS_ActorSpace = 1,

--- a/src/BmSDK/Generated/Engine/SkelControlSpline.g.cs
+++ b/src/BmSDK/Generated/Engine/SkelControlSpline.g.cs
@@ -81,7 +81,7 @@ public partial class SkelControlSpline : BmSDK.Engine.SkelControlBase, BmSDK.IGa
     /// <summary>
     /// Enum: ESplineControlRotMode
     /// </summary>
-    public enum ESplineControlRotMode
+    public enum ESplineControlRotMode : byte
     {
         SCR_NoChange = 0,
         SCR_AlongSpline = 1,

--- a/src/BmSDK/Generated/Engine/SkeletalMesh.g.cs
+++ b/src/BmSDK/Generated/Engine/SkeletalMesh.g.cs
@@ -115,7 +115,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: SoftBodyBoneType
     /// </summary>
-    public enum SoftBodyBoneType
+    public enum SoftBodyBoneType : byte
     {
         SOFTBODYBONE_Fixed = 0,
         SOFTBODYBONE_BreakableAttachment = 1,
@@ -185,7 +185,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ClothBoneType
     /// </summary>
-    public enum ClothBoneType
+    public enum ClothBoneType : byte
     {
         CLOTHBONE_Fixed = 0,
         CLOTHBONE_BreakableAttachment = 1,
@@ -309,7 +309,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: TriangleSortAxis
     /// </summary>
-    public enum TriangleSortAxis
+    public enum TriangleSortAxis : byte
     {
         TSA_X_Axis = 0,
         TSA_Y_Axis = 1,
@@ -320,7 +320,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ClothMovementScaleGen
     /// </summary>
-    public enum ClothMovementScaleGen
+    public enum ClothMovementScaleGen : byte
     {
         ECMDM_DistToFixedVert = 0,
         ECMDM_VertexBoneWeight = 1,
@@ -331,7 +331,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: TriangleSortOption
     /// </summary>
-    public enum TriangleSortOption
+    public enum TriangleSortOption : byte
     {
         TRISORT_None = 0,
         TRISORT_CenterRadialDistance = 1,
@@ -346,7 +346,7 @@ public partial class SkeletalMesh : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: BoneBreakOption
     /// </summary>
-    public enum BoneBreakOption
+    public enum BoneBreakOption : byte
     {
         BONEBREAK_SoftPreferred = 0,
         BONEBREAK_AutoDetect = 1,

--- a/src/BmSDK/Generated/Engine/SkeletalMeshComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/SkeletalMeshComponent.g.cs
@@ -2735,7 +2735,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EPhysBodyOp
     /// </summary>
-    public enum EPhysBodyOp
+    public enum EPhysBodyOp : byte
     {
         PBO_None = 0,
         PBO_Term = 1,
@@ -2843,7 +2843,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EDepthBiasApplicationType
     /// </summary>
-    public enum EDepthBiasApplicationType
+    public enum EDepthBiasApplicationType : byte
     {
         DEPTHBIASAPPLICATIONTYPE_World = 0,
         DEPTHBIASAPPLICATIONTYPE_Screen = 1,
@@ -2854,7 +2854,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EDepthBiasCalculationType
     /// </summary>
-    public enum EDepthBiasCalculationType
+    public enum EDepthBiasCalculationType : byte
     {
         DEPTHBIASCALCULATIONTYPE_Constant = 0,
         DEPTHBIASCALCULATIONTYPE_DirectionVariable = 1,
@@ -2864,7 +2864,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EFaceFXRegOp
     /// </summary>
-    public enum EFaceFXRegOp
+    public enum EFaceFXRegOp : byte
     {
         FXRO_Add = 0,
         FXRO_Multiply = 1,
@@ -2875,7 +2875,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EFaceFXBlendMode
     /// </summary>
-    public enum EFaceFXBlendMode
+    public enum EFaceFXBlendMode : byte
     {
         FXBM_Overwrite = 0,
         FXBM_Additive = 1,
@@ -2885,7 +2885,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: ERootMotionRotationMode
     /// </summary>
-    public enum ERootMotionRotationMode
+    public enum ERootMotionRotationMode : byte
     {
         RMRM_Ignore = 0,
         RMRM_RotateActor = 1,
@@ -2895,7 +2895,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: ERootMotionMode
     /// </summary>
-    public enum ERootMotionMode
+    public enum ERootMotionMode : byte
     {
         RMM_Translate = 0,
         RMM_Velocity = 1,
@@ -2949,7 +2949,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EInstanceWeightUsage
     /// </summary>
-    public enum EInstanceWeightUsage
+    public enum EInstanceWeightUsage : byte
     {
         IWU_PartialSwap = 0,
         IWU_FullSwap = 1,
@@ -3036,7 +3036,7 @@ public partial class SkeletalMeshComponent : BmSDK.Engine.MeshComponent, BmSDK.I
     /// <summary>
     /// Enum: EMaxDistanceScaleMode
     /// </summary>
-    public enum EMaxDistanceScaleMode
+    public enum EMaxDistanceScaleMode : byte
     {
         MDSM_Multiply = 0,
         MDSM_Substract = 1,

--- a/src/BmSDK/Generated/Engine/SoundNodeWave.g.cs
+++ b/src/BmSDK/Generated/Engine/SoundNodeWave.g.cs
@@ -465,7 +465,7 @@ public partial class SoundNodeWave : BmSDK.Engine.SoundNode, BmSDK.IGameObject
     /// <summary>
     /// Enum: EDecompressionType
     /// </summary>
-    public enum EDecompressionType
+    public enum EDecompressionType : byte
     {
         DTYPE_Setup = 0,
         DTYPE_Invalid = 1,

--- a/src/BmSDK/Generated/Engine/SpeedTreeComponent.g.cs
+++ b/src/BmSDK/Generated/Engine/SpeedTreeComponent.g.cs
@@ -388,7 +388,7 @@ public partial class SpeedTreeComponent : BmSDK.Engine.PrimitiveComponent, BmSDK
     /// <summary>
     /// Enum: ESpeedTreeMeshType
     /// </summary>
-    public enum ESpeedTreeMeshType
+    public enum ESpeedTreeMeshType : byte
     {
         STMT_MinMinusOne = 0,
         STMT_Branches1 = 1,

--- a/src/BmSDK/Generated/Engine/TerrainMaterial.g.cs
+++ b/src/BmSDK/Generated/Engine/TerrainMaterial.g.cs
@@ -81,7 +81,7 @@ public partial class TerrainMaterial : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETerrainMappingType
     /// </summary>
-    public enum ETerrainMappingType
+    public enum ETerrainMappingType : byte
     {
         TMT_Auto = 0,
         TMT_XY = 1,

--- a/src/BmSDK/Generated/Engine/Texture.g.cs
+++ b/src/BmSDK/Generated/Engine/Texture.g.cs
@@ -496,7 +496,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureMipGenSettings
     /// </summary>
-    public enum TextureMipGenSettings
+    public enum TextureMipGenSettings : byte
     {
         TMGS_FromTextureGroup = 0,
         TMGS_SimpleAverage = 1,
@@ -819,7 +819,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureGroup
     /// </summary>
-    public enum TextureGroup
+    public enum TextureGroup : byte
     {
         TEXTUREGROUP_World = 0,
         TEXTUREGROUP_WorldNormalMap = 1,
@@ -859,7 +859,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureAddress
     /// </summary>
-    public enum TextureAddress
+    public enum TextureAddress : byte
     {
         TA_Wrap = 0,
         TA_Clamp = 1,
@@ -870,7 +870,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureFilter
     /// </summary>
-    public enum TextureFilter
+    public enum TextureFilter : byte
     {
         TF_Nearest = 0,
         TF_Linear = 1,
@@ -880,7 +880,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: EPixelFormat
     /// </summary>
-    public enum EPixelFormat
+    public enum EPixelFormat : byte
     {
         PF_Unknown = 0,
         PF_A32B32G32R32F = 1,
@@ -916,7 +916,7 @@ public partial class Texture : BmSDK.Engine.Surface, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureCompressionSettings
     /// </summary>
-    public enum TextureCompressionSettings
+    public enum TextureCompressionSettings : byte
     {
         TC_Default = 0,
         TC_Normalmap = 1,

--- a/src/BmSDK/Generated/Engine/TextureFlipBook.g.cs
+++ b/src/BmSDK/Generated/Engine/TextureFlipBook.g.cs
@@ -155,7 +155,7 @@ public partial class TextureFlipBook : BmSDK.Engine.Texture2D, BmSDK.IGameObject
     /// <summary>
     /// Enum: TextureFlipBookMethod
     /// </summary>
-    public enum TextureFlipBookMethod
+    public enum TextureFlipBookMethod : byte
     {
         TFBM_UL_ROW = 0,
         TFBM_UL_COL = 1,

--- a/src/BmSDK/Generated/Engine/TextureMovie.g.cs
+++ b/src/BmSDK/Generated/Engine/TextureMovie.g.cs
@@ -191,7 +191,7 @@ public partial class TextureMovie : BmSDK.Engine.Texture, BmSDK.IGameObject
     /// <summary>
     /// Enum: EMovieStreamSource
     /// </summary>
-    public enum EMovieStreamSource
+    public enum EMovieStreamSource : byte
     {
         MovieStream_File = 0,
         MovieStream_Memory = 1,

--- a/src/BmSDK/Generated/Engine/UIDataProvider.g.cs
+++ b/src/BmSDK/Generated/Engine/UIDataProvider.g.cs
@@ -269,7 +269,7 @@ public partial class UIDataProvider : BmSDK.Engine.UIRoot, BmSDK.IGameObject
     /// <summary>
     /// Enum: EProviderAccessType
     /// </summary>
-    public enum EProviderAccessType
+    public enum EProviderAccessType : byte
     {
         ACCESS_ReadOnly = 0,
         ACCESS_PerField = 1,

--- a/src/BmSDK/Generated/Engine/UIDataStore_OnlineStats.g.cs
+++ b/src/BmSDK/Generated/Engine/UIDataStore_OnlineStats.g.cs
@@ -76,7 +76,7 @@ public partial class UIDataStore_OnlineStats : BmSDK.Engine.UIDataStore_Remote, 
     /// <summary>
     /// Enum: EStatsFetchType
     /// </summary>
-    public enum EStatsFetchType
+    public enum EStatsFetchType : byte
     {
         SFT_Player = 0,
         SFT_CenteredOnPlayer = 1,

--- a/src/BmSDK/Generated/Engine/UIRoot.g.cs
+++ b/src/BmSDK/Generated/Engine/UIRoot.g.cs
@@ -684,7 +684,7 @@ public partial class UIRoot : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EInputPlatformType
     /// </summary>
-    public enum EInputPlatformType
+    public enum EInputPlatformType : byte
     {
         IPT_PC = 0,
         IPT = 1,
@@ -695,7 +695,7 @@ public partial class UIRoot : BmSDK.StateObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: EUIDataProviderFieldType
     /// </summary>
-    public enum EUIDataProviderFieldType
+    public enum EUIDataProviderFieldType : byte
     {
         DATATYPE_Property = 0,
         DATATYPE_Provider = 1,

--- a/src/BmSDK/Generated/Engine/UberPostProcessEffect.g.cs
+++ b/src/BmSDK/Generated/Engine/UberPostProcessEffect.g.cs
@@ -81,7 +81,7 @@ public partial class UberPostProcessEffect : BmSDK.Engine.DOFBloomMotionBlurEffe
     /// <summary>
     /// Enum: ETonemapperType
     /// </summary>
-    public enum ETonemapperType
+    public enum ETonemapperType : byte
     {
         Tonemapper_Off = 0,
         Tonemapper_Filmic = 1,

--- a/src/BmSDK/Generated/Engine/Weapon.g.cs
+++ b/src/BmSDK/Generated/Engine/Weapon.g.cs
@@ -1143,7 +1143,7 @@ public partial class Weapon : BmSDK.Engine.Inventory, BmSDK.IGameObject
     /// <summary>
     /// Enum: EWeaponFireType
     /// </summary>
-    public enum EWeaponFireType
+    public enum EWeaponFireType : byte
     {
         EWFT_InstantHit = 0,
         EWFT_Projectile = 1,

--- a/src/BmSDK/Generated/Engine/WorldInfo.g.cs
+++ b/src/BmSDK/Generated/Engine/WorldInfo.g.cs
@@ -1021,7 +1021,7 @@ public partial class WorldInfo : BmSDK.Engine.ZoneInfo, BmSDK.IGameObject
     /// <summary>
     /// Enum: EHostMigrationProgress
     /// </summary>
-    public enum EHostMigrationProgress
+    public enum EHostMigrationProgress : byte
     {
         HostMigration_None = 0,
         HostMigration_FindingNewHost = 1,
@@ -1369,7 +1369,7 @@ public partial class WorldInfo : BmSDK.Engine.ZoneInfo, BmSDK.IGameObject
     /// <summary>
     /// Enum: EVisibilityAggressiveness
     /// </summary>
-    public enum EVisibilityAggressiveness
+    public enum EVisibilityAggressiveness : byte
     {
         VIS_LeastAggressive = 0,
         VIS_ModeratelyAggressive = 1,
@@ -1459,7 +1459,7 @@ public partial class WorldInfo : BmSDK.Engine.ZoneInfo, BmSDK.IGameObject
     /// <summary>
     /// Enum: EConsoleType
     /// </summary>
-    public enum EConsoleType
+    public enum EConsoleType : byte
     {
         CONSOLE_Any = 0,
         CONSOLE_Xbox360 = 1,
@@ -1783,7 +1783,7 @@ public partial class WorldInfo : BmSDK.Engine.ZoneInfo, BmSDK.IGameObject
     /// <summary>
     /// Enum: ENetMode
     /// </summary>
-    public enum ENetMode
+    public enum ENetMode : byte
     {
         NM_Standalone = 0,
         NM_DedicatedServer = 1,

--- a/src/BmSDK/Generated/Engine/_Engine.g.cs
+++ b/src/BmSDK/Generated/Engine/_Engine.g.cs
@@ -585,7 +585,7 @@ public partial class _Engine : BmSDK.Subsystem, BmSDK.IGameObject
     /// <summary>
     /// Enum: ETransitionType
     /// </summary>
-    public enum ETransitionType
+    public enum ETransitionType : byte
     {
         TT_None = 0,
         TT_Paused = 1,

--- a/src/BmSDK/Generated/GFxUI/GFxMoviePlayer.g.cs
+++ b/src/BmSDK/Generated/GFxUI/GFxMoviePlayer.g.cs
@@ -1427,7 +1427,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GFxAlign
     /// </summary>
-    public enum GFxAlign
+    public enum GFxAlign : byte
     {
         Align_Center = 0,
         Align_TopCenter = 1,
@@ -1444,7 +1444,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GFxScaleMode
     /// </summary>
-    public enum GFxScaleMode
+    public enum GFxScaleMode : byte
     {
         SM_NoScale = 0,
         SM_ShowAll = 1,
@@ -1499,7 +1499,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: ASType
     /// </summary>
-    public enum ASType
+    public enum ASType : byte
     {
         AS_Undefined = 0,
         AS_Null = 1,
@@ -1652,7 +1652,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GFxRenderTextureMode
     /// </summary>
-    public enum GFxRenderTextureMode
+    public enum GFxRenderTextureMode : byte
     {
         RTM_Opaque = 0,
         RTM_Alpha = 1,
@@ -1663,7 +1663,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GFxTimingMode
     /// </summary>
-    public enum GFxTimingMode
+    public enum GFxTimingMode : byte
     {
         TM_Game = 0,
         TM_Real = 1,
@@ -1673,7 +1673,7 @@ public partial class GFxMoviePlayer : BmSDK.GameObject, BmSDK.IGameObject
     /// <summary>
     /// Enum: GFxDPGBias
     /// </summary>
-    public enum GFxDPGBias
+    public enum GFxDPGBias : byte
     {
         DPGB_BackMost = 0,
         DPGB_UnderHUD = 1,

--- a/src/BmSDK/Generated/GFxUI/SwfMovie.g.cs
+++ b/src/BmSDK/Generated/GFxUI/SwfMovie.g.cs
@@ -180,7 +180,7 @@ public partial class SwfMovie : BmSDK.GFxUI.GFxRawData, BmSDK.IGameObject
     /// <summary>
     /// Enum: FlashTextureRescale
     /// </summary>
-    public enum FlashTextureRescale
+    public enum FlashTextureRescale : byte
     {
         FlashTextureScale_High = 0,
         FlashTextureScale_Low = 1,

--- a/src/BmSDK/Generated/IpDrv/OnlineEventsInterfaceMcp.g.cs
+++ b/src/BmSDK/Generated/IpDrv/OnlineEventsInterfaceMcp.g.cs
@@ -242,7 +242,7 @@ public partial class OnlineEventsInterfaceMcp : BmSDK.IpDrv.MCPBase, BmSDK.Engin
     /// <summary>
     /// Enum: EEventUploadType
     /// </summary>
-    public enum EEventUploadType
+    public enum EEventUploadType : byte
     {
         EUT_GenericStats = 0,
         EUT_ProfileData = 1,


### PR DESCRIPTION
Fixes an issue where reading/writing to an enum would read 4 bytes instead of 1