### PR TITLE
fix: redirects of base functions causing infinite recursion 

### DIFF
--- a/src/BmSDK/Classes/Core/Function.cs
+++ b/src/BmSDK/Classes/Core/Function.cs
@@ -44,4 +44,11 @@ public partial class Function
                 && !prop.PropertyFlags.HasFlag(Property.EPropertyFlags.CPF_ReturnParm)
             );
     }
+
+    public Property? GetReturnParam() =>
+        EnumerateFields()
+            .OfType<Property>()
+            .FirstOrDefault(prop =>
+                prop.PropertyFlags.HasFlag(Property.EPropertyFlags.CPF_ReturnParm)
+            );
 }

--- a/src/BmSDK/Classes/Core/Struct.cs
+++ b/src/BmSDK/Classes/Core/Struct.cs
@@ -7,30 +7,21 @@ public partial class Struct
     /// <summary>
     /// Property: Children
     /// </summary>
-    public Struct SuperStruct
-    {
-        get => MarshalUtil.ToManaged<Struct>(Ptr + 56);
-    }
+    public Struct SuperStruct => MarshalUtil.ToManaged<Struct>(Ptr + 56);
 
     /// <summary>
     /// Property: Children
     /// </summary>
-    public Field Children
-    {
-        get => MarshalUtil.ToManaged<Field>(Ptr + 60);
-    }
+    public Field Children => MarshalUtil.ToManaged<Field>(Ptr + 60);
 
     /// <summary>
     /// Property: PropertiesSize
     /// </summary>
-    public short PropertiesSize
-    {
-        get => MarshalUtil.ToManaged<short>(Ptr + 64);
-    }
+    public short PropertiesSize => MarshalUtil.ToManaged<short>(Ptr + 64);
 
     public IEnumerable<Field> EnumerateFields()
     {
-        for (Field fieldLink = Children; fieldLink != null; fieldLink = fieldLink.Next)
+        for (var fieldLink = Children; fieldLink != null; fieldLink = fieldLink.Next)
         {
             yield return fieldLink;
         }
@@ -41,11 +32,9 @@ public partial class Struct
     /// </summary>
     public IEnumerable<Struct> EnumerateSupersAndSelf()
     {
-        var super = this;
-        while (super is not null)
+        for (var super = this; super != null; super = super.SuperStruct)
         {
             yield return super;
-            super = super.SuperStruct;
         }
     }
 }

--- a/src/BmSDK/FrameworkInternal/Redirection/RedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/RedirectManager.cs
@@ -92,7 +92,7 @@ internal static class RedirectManager
             {
                 // Call redirect if exists
                 var redir = lastCall.NextRedirect();
-                if (redir != null)
+                if (redir is not null)
                 {
                     redir.Run(selfObj, funcObj, stackPtr, Result);
                     return true;
@@ -100,9 +100,11 @@ internal static class RedirectManager
                 // Call base implementation only once after redirects
                 else if (lastCall.TargetFunc != funcObj)
                 {
-                    stackPtr->Node = lastCall.TargetFunc.Ptr;
+                    lastCall.RunOriginal(stackPtr, Result);
+                    return true;
                 }
 
+                // Let base implementation run from RunOriginal call
                 return false;
             }
         }

--- a/src/BmSDK/FrameworkInternal/Redirection/RedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/RedirectManager.cs
@@ -86,18 +86,24 @@ internal static class RedirectManager
         // Prevent infinite recursion: if top of stack is the function object, treat as reentry
         if (s_redirectCalls.TryPeek(out var lastCall))
         {
-            if (lastCall.TargetObj == selfObj && lastCall.TargetFunc == funcObj)
+            // Atp we know this func is called by a redirect
+            // Therefore, it's okay and necessary to check for function overrides
+            if (lastCall.TargetObj == selfObj && funcObj.EnumerateSupersAndSelf().Contains(lastCall.TargetFunc))
             {
+                // Call redirect if exists
                 var redir = lastCall.NextRedirect();
                 if (redir != null)
                 {
                     redir.Run(selfObj, funcObj, stackPtr, Result);
                     return true;
                 }
-                else
+                // Call base implementation only once after redirects
+                else if (lastCall.TargetFunc != funcObj)
                 {
-                    return false;
+                    stackPtr->Node = lastCall.TargetFunc.Ptr;
                 }
+
+                return false;
             }
         }
 

--- a/src/BmSDK/FrameworkInternal/Redirection/Redirects.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/Redirects.cs
@@ -111,4 +111,37 @@ internal sealed record RedirectCall(
 
     public IGenericRedirect? NextRedirect() =>
         _currIndex < Redirs.Length ? Redirs[_currIndex++] : null;
+
+    public unsafe void RunOriginal(FFrame* stackPtr, IntPtr result)
+    {
+        // Copy over args to new buffer for call to original function
+        var paramsSize = TargetFunc.EnumerateParams().Sum(p => p.ElementSize);
+        var argsPtr = stackalloc byte[TargetFunc.PropertiesSize];
+        Buffer.MemoryCopy(
+            stackPtr->Locals.ToPointer(),
+            argsPtr,
+            paramsSize,
+            paramsSize
+        );
+
+        // Call the actual target function and not an override
+        GameFunctions.ProcessEvent(
+            TargetObj.Ptr,
+            TargetFunc.Ptr,
+            (IntPtr)argsPtr,
+            IntPtr.Zero
+        );
+
+        // If there is a return value, pass it through
+        var returnField = TargetFunc.GetReturnParam();
+        if (returnField is not null)
+        {
+            Buffer.MemoryCopy(
+                argsPtr + returnField.Offset,
+                result.ToPointer(),
+                returnField.ElementSize,
+                returnField.ElementSize
+            );
+        }
+    }
 }


### PR DESCRIPTION
Dear Bit,

The old implementation of RedirectManager caused some redirects of base functions to recursively loop forever. I have fixed this by detecting if a child function is called from a redirected base function in which case I now force run the original target function. I have tested this patch and it passes the checks which it didn't before. I also didn't notice any regressions. The only things that are unsupported are out parameters which were broken before anyway. When we revisit this we should just keep in mind that this is a place that will need refactoring too.

Yours sincerely,
Samuil1337
