### PR TITLE
feat: print error messages to on-screen overlay

### DIFF
--- a/bin/BmGame/Mods/ModTemplate/scripts/ModTemplateScript.cs
+++ b/bin/BmGame/Mods/ModTemplate/scripts/ModTemplateScript.cs
@@ -8,7 +8,5 @@ public class ModTemplateScript : Script
     public override void Main()
     {
         Debug.Log("Hello from ModTemplate!");
-
-        compilerror
     }
 }

--- a/bin/BmGame/Mods/ModTemplate/scripts/ModTemplateScript.cs
+++ b/bin/BmGame/Mods/ModTemplate/scripts/ModTemplateScript.cs
@@ -8,5 +8,7 @@ public class ModTemplateScript : Script
     public override void Main()
     {
         Debug.Log("Hello from ModTemplate!");
+
+        compilerror
     }
 }

--- a/src/BmSDK/Framework/Debug.cs
+++ b/src/BmSDK/Framework/Debug.cs
@@ -14,21 +14,7 @@ public static class Debug
         [CallerFilePath] string? callerFilePath = null
     )
     {
-        var msgText = msg?.ToString() ?? "null";
-
-        if (skipSender)
-        {
-            Trace.WriteLine(msg);
-            return;
-        }
-
-        // Get sender, else fall back to the source file name.
-        if (!s_senderStack.TryPeek(out var sender))
-        {
-            sender = callerFilePath is null ? "UNKNOWN" : Path.GetFileName(callerFilePath);
-        }
-
-        Trace.WriteLine($"{sender}: {msgText}");
+        Trace.WriteLine(FormatLine(msg, skipSender, callerFilePath));
     }
 
     public static void LogWarning(
@@ -48,9 +34,29 @@ public static class Debug
         [CallerFilePath] string? callerFilePath = null
     )
     {
+        var line = FormatLine(msg, skipSender, callerFilePath);
+        ErrorOverlay.Add(line);
+
         Console.ForegroundColor = ConsoleColor.Red;
-        Log(msg, skipSender, callerFilePath);
+        Trace.WriteLine(line);
         Console.ForegroundColor = s_defaultColor;
+    }
+
+    private static string FormatLine(object? msg, bool skipSender, string? callerFilePath)
+    {
+        var msgText = msg?.ToString() ?? "null";
+        if (skipSender)
+        {
+            return msgText;
+        }
+
+        // Get sender, else fall back to the source file name.
+        if (!s_senderStack.TryPeek(out var sender))
+        {
+            sender = callerFilePath is null ? "UNKNOWN" : Path.GetFileName(callerFilePath);
+        }
+
+        return $"{sender}: {msgText}";
     }
 
     internal static void PushSender(string sender)

--- a/src/BmSDK/FrameworkInternal/ErrorOverlay.cs
+++ b/src/BmSDK/FrameworkInternal/ErrorOverlay.cs
@@ -1,0 +1,68 @@
+using BmSDK.Engine;
+
+namespace BmSDK.Framework;
+
+/// <summary>
+/// Draws error lines on top of the game viewport. Populated by <see cref="Debug.LogError"/>
+/// and cleared on hot reload.
+/// </summary>
+internal static class ErrorOverlay
+{
+    private static readonly Lock s_lock = new();
+    private static readonly List<string> s_lines = [];
+
+    private const float MarginX = 16f;
+    private const float MarginY = 16f;
+    private const float LineHeight = 16f;
+
+    public static void Add(string line)
+    {
+        lock (s_lock)
+        {
+            s_lines.Add(line);
+        }
+    }
+
+    public static void Clear()
+    {
+        lock (s_lock)
+        {
+            s_lines.Clear();
+        }
+    }
+
+    [Redirect(typeof(GameViewportClient), nameof(GameViewportClient.PostRender))]
+    private static void PostRenderRedirect(GameViewportClient self, Canvas canvas)
+    {
+        // Let the engine do its normal HUD/console/transition rendering first so our
+        // banner draws on top.
+        self.PostRender(canvas);
+
+        string[] snapshot;
+        lock (s_lock)
+        {
+            if (s_lines.Count == 0)
+            {
+                return;
+            }
+
+            snapshot = [.. s_lines];
+        }
+
+        Draw(canvas, snapshot);
+    }
+
+    private static void Draw(Canvas canvas, string[] lines)
+    {
+        // canvas.Font = _Engine.GetSmallFont();
+        canvas.SetDrawColor(255, 64, 64, 255);
+
+        var y = MarginY;
+        foreach (var line in lines)
+        {
+            canvas.SetPos(MarginX, y, 0f);
+            canvas.DrawText(line, CR: false, XScale: 1f, YScale: 1f, out _);
+            y += LineHeight;
+        }
+    }
+}

--- a/src/BmSDK/FrameworkInternal/ErrorOverlay.cs
+++ b/src/BmSDK/FrameworkInternal/ErrorOverlay.cs
@@ -54,7 +54,6 @@ internal static class ErrorOverlay
 
     private static void Draw(Canvas canvas, string[] lines)
     {
-        // canvas.Font = _Engine.GetSmallFont();
         canvas.SetDrawColor(255, 64, 64, 255);
 
         var y = MarginY;

--- a/src/BmSDK/FrameworkInternal/ScriptManager.cs
+++ b/src/BmSDK/FrameworkInternal/ScriptManager.cs
@@ -219,6 +219,8 @@ internal static class ScriptManager
     {
         lock (s_lockObj)
         {
+            ErrorOverlay.Clear();
+
             try
             {
                 var scriptsDir = FileUtils.GetScriptsPath();

--- a/src/BmSDK/Loader.cs
+++ b/src/BmSDK/Loader.cs
@@ -42,6 +42,9 @@ internal static class Loader
         // Find/load scripts
         ScriptManager.Init();
 
+        // Register BmSDK's internal redirectors.
+        RedirectManager.Global.RegisterRedirectors(typeof(Loader).Assembly);
+
         // Create function detours
         _EngineTickDetourBase = DetourUtil.NewDetour<GameFunctions.EngineTickDelegate>(
             GameInfo.FuncOffsets.EngineTick,


### PR DESCRIPTION
Messages printed by `Debug.LogError` now appear on-screen, and persist until hot reload or restart

<img width="626" height="337" alt="Screenshot 2026-05-16 161847" src="https://github.com/user-attachments/assets/b3b2e05d-5628-4345-a53b-132ed5391ef9" />
