### PR TITLE
chore: add Mods directory to .code-workspace

### DIFF
--- a/bin/BmGame/ScriptsDev/ScriptsDev.code-workspace
+++ b/bin/BmGame/ScriptsDev/ScriptsDev.code-workspace
@@ -8,6 +8,10 @@
 			"name": "Scripts",
 			"path": "./../Scripts",
 		},
+		{
+			"name": "Mods",
+			"path": "./../Mods",
+		},
 	],
 	"settings": {
 		"dotnet.defaultSolution": "./ScriptsDev.slnx",


### PR DESCRIPTION
Dear Bit,

When we added support for the new Mods format we missed to add the Mods directory to the ScriptsDev.code-workspace. It's fixed now.

Yours sincerely,
Samuil1337
