### PR TITLE
feat: allow a function to global redir multiple types

### DIFF
--- a/src/BmSDK/Framework/Attributes/RedirectAttribute.cs
+++ b/src/BmSDK/Framework/Attributes/RedirectAttribute.cs
@@ -8,7 +8,9 @@ namespace BmSDK.Framework;
 /// <remarks>The method being marked must be static. If the target UFunction is not static
 /// the detour must take an artificial self parameter  of the <see cref="TargetType"/> as the first argument.
 /// The return type and the parameter types that follow (the function signature) must match the actual method exactly
-/// (both types and order). Names and the method's access modifier are irrelevant.</remarks>
+/// (both types and order). Names and the method's access modifier are irrelevant.
+/// Multiple RedirectAttributes are allowed on the same function as long as the target type and/or (less commonly)
+/// target UFunction is altered. In that case, multiple, independent redirects will be registered.</remarks>
 /// <example>
 /// [Redirect(typeof(RPawnPlayer), nameof(RPawnPlayer.ExperienceAwarded))]
 /// private static void ExperienceAwardedRedirect(RPawnPlayer self, int xp, int teethXp)

--- a/src/BmSDK/Framework/Attributes/RedirectAttribute.cs
+++ b/src/BmSDK/Framework/Attributes/RedirectAttribute.cs
@@ -21,7 +21,7 @@ namespace BmSDK.Framework;
 /// Use <see langword="typeof"/> to get it safely.</param>
 /// <param name="targetMethod">The name of the method on the target type to which calls are redirected.
 /// Use <see langword="nameof"/> to get it safely.</param>
-[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 public sealed class RedirectAttribute(Type targetType, string targetMethod) : Attribute
 {
     public Type TargetType { get; } = targetType;

--- a/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
@@ -44,12 +44,22 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
         var declaringFuncPath = StaticInit.GetDeclaringFuncPath(targetType, redirAttr.TargetMethod);
 
         // Store the redirect for later use.
-        var redirInfo = new GlobalRedirectorInfo(targetType, redirAttr.AllowSubtypes, redirectMi, redirectMi.DeclaringType!.Assembly);
+        var redirInfo = new GlobalRedirectorInfo(
+            targetType,
+            redirAttr.AllowSubtypes,
+            redirectMi,
+            redirectMi.DeclaringType!.Assembly
+        );
 
         // Add new redirect to the target function's redirect list
         if (_globalRedirsDict.TryGetValue(declaringFuncPath, out var redirects))
         {
-            if (redirects.Any(r => r.RedirectMethod == redirInfo.RedirectMethod && r.TargetType == redirInfo.TargetType))
+            if (
+                redirects.Any(r =>
+                    r.RedirectMethod == redirInfo.RedirectMethod
+                    && r.TargetType == redirInfo.TargetType
+                )
+            )
             {
                 throw new InvalidOperationException(
                     $"{redirInfo} has already been registered once on {declaringFuncPath}!"

--- a/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
@@ -75,13 +75,10 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
         {
             foreach (var func in type.GetMethods(_globalRedirSearchFlags))
             {
-                var redirAttr = func.GetCustomAttribute<RedirectAttribute>();
-                if (redirAttr == null)
+                foreach (var redirAttr in func.GetCustomAttributes<RedirectAttribute>())
                 {
-                    continue;
+                    RegisterRedirector(redirAttr, func);
                 }
-
-                RegisterRedirector(redirAttr, func);
             }
         }
     }

--- a/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
@@ -19,6 +19,23 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
     private readonly Dictionary<string, List<GlobalRedirectorInfo>> _globalRedirsDict = [];
 
     /// <summary>
+    /// Registers all functions marked with a <see cref="RedirectAttribute"/> in a given assembly.
+    /// </summary>
+    public void RegisterRedirectors(Assembly asm)
+    {
+        foreach (var type in asm.GetTypes())
+        {
+            foreach (var func in type.GetMethods(_globalRedirSearchFlags))
+            {
+                foreach (var redirAttr in func.GetCustomAttributes<RedirectAttribute>())
+                {
+                    RegisterRedirector(redirAttr, func);
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Registers a delegate as a redirector for the given in-game function.
     /// </summary>
     /// <param name="redirAttr">Attribute containing metadata for registration</param>
@@ -54,6 +71,8 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
         // Add new redirect to the target function's redirect list
         if (_globalRedirsDict.TryGetValue(declaringFuncPath, out var redirects))
         {
+            // Prevent the same managed function from being used on the same target type
+            // as that would likely be a bug
             if (
                 redirects.Any(r =>
                     r.RedirectMethod == redirInfo.RedirectMethod
@@ -77,23 +96,6 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
     }
 
     /// <summary>
-    /// Registers all functions marked with a <see cref="RedirectAttribute"/> in a given assembly.
-    /// </summary>
-    public void RegisterRedirectors(Assembly asm)
-    {
-        foreach (var type in asm.GetTypes())
-        {
-            foreach (var func in type.GetMethods(_globalRedirSearchFlags))
-            {
-                foreach (var redirAttr in func.GetCustomAttributes<RedirectAttribute>())
-                {
-                    RegisterRedirector(redirAttr, func);
-                }
-            }
-        }
-    }
-
-    /// <summary>
     /// Gets any redirections for the given function path if it applies to the given GameObject.
     /// </summary>
     /// <returns>Objects representing the registered global redirects.
@@ -113,8 +115,10 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
             {
                 return objType.IsAssignableTo(info.TargetType);
             }
-
-            return objType == info.TargetType;
+            else
+            {
+                return objType == info.TargetType;
+            }
         });
     }
 

--- a/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
+++ b/src/BmSDK/FrameworkInternal/Redirection/GlobalRedirectManager.cs
@@ -49,10 +49,10 @@ internal sealed class GlobalRedirectManager(BindingFlags genericRedirSearchFlags
         // Add new redirect to the target function's redirect list
         if (_globalRedirsDict.TryGetValue(declaringFuncPath, out var redirects))
         {
-            if (redirects.Any(r => r.RedirectMethod == redirInfo.RedirectMethod))
+            if (redirects.Any(r => r.RedirectMethod == redirInfo.RedirectMethod && r.TargetType == redirInfo.TargetType))
             {
                 throw new InvalidOperationException(
-                    $"{redirInfo} has already been registered once" + $"on {declaringFuncPath}!"
+                    $"{redirInfo} has already been registered once on {declaringFuncPath}!"
                 );
             }
         }

--- a/src/BmSDK/FrameworkInternal/StaticInit.cs
+++ b/src/BmSDK/FrameworkInternal/StaticInit.cs
@@ -5,7 +5,7 @@ namespace BmSDK.Framework;
 internal static partial class StaticInit
 {
     private const BindingFlags FuncSearchFlags =
-        BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public;
+        BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
     public static Type GetManagedTypeForClassPath(string classPath)
     {
@@ -52,9 +52,8 @@ internal static partial class StaticInit
     /// <exception cref="ArgumentException">If the method couldn't be found.</exception>
     public static Type GetDeclaringTypeForMethod(Type type, string methodName) =>
         Guard.NotNull(
-            EnumerateSelfAndSupers(type)
-                .FirstOrDefault(super => super.GetMethod(methodName, FuncSearchFlags) != null),
-            $"{type.Name} and its supers have no declaration of the method '{methodName}'."
+            type.GetMethod(methodName, FuncSearchFlags)?.DeclaringType,
+            $"{type} and its supers have no declaration of the method '{methodName}'."
         );
 
     /// <summary>


### PR DESCRIPTION
Dear Bit,

There are some instances where a single function could be used 1:1 as a redirect for multiple types. Take this for example:
```csharp
[Redirect(typeof(RPawnPlayer), nameof(RPawnPlayer.AddDefaultInventoryAfterInit))]
[Redirect(typeof(RPawnPlayerBm), nameof(RPawnPlayerBm.AddDefaultInventoryAfterInit))]
static void AddDefaultInventoryAfterInit(RPawnPlayer self)
{
    self.AddDefaultInventoryAfterInit();
    Debug.Log("Added default inventory after init");
}
```
`RPawnPlayerBm` overrides the base function without calling the base implementation. This would mean that a redirect on `RPawnPlayer` would not be executed. This is the intended behavior in many cases. However, the game often uses this pattern for logic specific to one pawn class (e.g. health, inventory). Allowing this style of syntax could help reduce the amount of boilerplate code necessary for some mods (e.g. [my character swapping script](https://github.com/Samuil1337/CharacterSwappingScript/blob/main/scripts/Patches/Health/ForceUseSavedArmor.cs)). On the other hand, there is a chance, silent bugs are introduced if you are not 100% sure that the base implementation isn't called (or if you don't set `AllowSubtypes` to false if necessary).

This PR adds this feature.

Best regards,
Samuil1337
