### PR TITLE
ci: switch to self-contained publishing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,15 +36,11 @@ jobs:
         cache: true
         cache-dependency-path: '**/packages.lock.json'
 
-    - name: "Restore NuGet packages"
-      run: |
-        dotnet restore '${{ env.PROJ_PATH }}' --locked-mode
-
     - name: "Build BmSDK in Release mode"
       run: >
         dotnet publish '${{ env.PROJ_PATH }}' -c Release
         -o '${{ env.STAGING_DIR }}/Binaries/Win32/sdk/'
-        --no-restore --nologo
+        -p:RestoreLockedMode=true --nologo
 
     - name: "Upload binaries for later processing"
       uses: actions/upload-artifact@v7

--- a/src/BmSDK.Host/runtime.cpp
+++ b/src/BmSDK.Host/runtime.cpp
@@ -51,10 +51,14 @@ namespace runtime {
 
     // Using the nethost library, discover the location of hostfxr and get exports
     static bool load_hostfxr() {
+        // Point to local hostfxr.dll (or fall back to global .NET copy if not a publish build)
+        const wstring assemblyPath = get_game_dir().wstring() + L"\\sdk\\BmSDK.dll";
+        get_hostfxr_parameters params{ sizeof(get_hostfxr_parameters), assemblyPath.c_str(), nullptr };
+
         // Pre-allocate a large buffer for the path to hostfxr
         char_t buffer[MAX_PATH];
         size_t buffer_size = sizeof(buffer) / sizeof(char_t);
-        int rc = get_hostfxr_path(buffer, &buffer_size, nullptr);
+        int rc = get_hostfxr_path(buffer, &buffer_size, &params);
         if (rc != 0)
             return false;
 

--- a/src/BmSDK/BmSDK.csproj
+++ b/src/BmSDK/BmSDK.csproj
@@ -7,6 +7,7 @@
   <!-- Build options -->
   <PropertyGroup>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishSelfContained>true</PublishSelfContained>
     <TargetFramework>net10.0-windows7.0</TargetFramework>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Use `<PublishSelfContained>` and prefer its copy of `hostfxr.dll` (only generated during publish so local builds can keep using the installed .NET copy)