### PR TITLE
ci: upload artifacts to releases with gh cli

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,7 +1,6 @@
 name: "Create release build"
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       tag_name:
@@ -12,6 +11,7 @@ on:
       artifact-id:
         description: "Artifact ID of final binary"
         value: ${{ jobs.create-package.outputs.artifact-id }}
+  workflow_dispatch:
 
 env:
   TARGET_REF: ${{ inputs.tag_name || github.sha }}
@@ -137,7 +137,7 @@ jobs:
       id: upload-artifact
       uses: actions/upload-artifact@v7
       with:
-        name: "BmSDK-${{ inputs.tag_name || github.sha }}"
+        name: "BmSDK-AC-${{ env.TARGET_REF}}"
         path: ${{ env.STAGING_DIR }}
         if-no-files-found: error
         compression-level: 9

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,8 +45,11 @@ jobs:
           skip-decompress: true
 
       - name: "Upload artifacts to release"
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: '${{ steps.download-build.outputs.download-path }}/*.zip'
-          draft: false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          files=("${{ steps.download-build.outputs.download-path }}"/*.zip)
+          gh release upload "${{ env.TAG_NAME }}" "${files[@]}"
+          gh release edit "${{ env.TAG_NAME }}" --draft=false


### PR DESCRIPTION
Dear Bit,

I dropped the dependency on softprops/action-gh-release and just use the gh CLI now.
New releases are also named BmSDK-**AC**-vX.Y.Z now to match AK.

Best regards,
Samuil1337
